### PR TITLE
Feature/custom headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 	uc.metrics = newMetrics(
 		metricsOptions{
 			appName:         uc.options.appName,
-			instanceID:      uc.options.instanceId,
+			instanceId:      uc.options.instanceId,
 			strategies:      strategyNames,
 			metricsInterval: uc.options.metricsInterval,
 			url:             *parsedUrl,

--- a/client.go
+++ b/client.go
@@ -140,6 +140,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			refreshInterval: uc.options.refreshInterval,
 			storage:         uc.options.storage,
 			httpClient:      uc.options.httpClient,
+			customHeaders:   uc.options.customHeaders,
 		},
 		repositoryChannels{
 			errorChannels: errChannels,
@@ -162,6 +163,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			metricsInterval: uc.options.metricsInterval,
 			url:             *parsedUrl,
 			httpClient:      uc.options.httpClient,
+			customHeaders:   uc.options.customHeaders,
 		},
 		metricsChannels{
 			errorChannels: errChannels,

--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ type configOption struct {
 	listener        interface{}
 	storage         Storage
 	httpClient      *http.Client
+	customHeaders	http.Header
 }
 
 // ConfigOption represents a option for configuring the client.
@@ -112,6 +113,14 @@ func WithHttpClient(client *http.Client) ConfigOption {
 	}
 }
 
+// WithCustomHeaders specifies any custom headers that should be sent along with requests to the
+// server.
+func WithCustomHeaders(headers http.Header) ConfigOption {
+	return func(o *configOption) {
+		o.customHeaders = headers
+	}
+}
+
 type featureOption struct {
 	fallback *bool
 	ctx      *context.Context
@@ -144,6 +153,7 @@ type repositoryOptions struct {
 	refreshInterval time.Duration
 	storage         Storage
 	httpClient      *http.Client
+	customHeaders	http.Header
 }
 
 type metricsOptions struct {
@@ -154,4 +164,5 @@ type metricsOptions struct {
 	metricsInterval time.Duration
 	disableMetrics  bool
 	httpClient      *http.Client
+	customHeaders   http.Header
 }

--- a/config.go
+++ b/config.go
@@ -148,7 +148,7 @@ type repositoryOptions struct {
 
 type metricsOptions struct {
 	appName         string
-	instanceID      string
+	instanceId      string
 	url             url.URL
 	strategies      []string
 	metricsInterval time.Duration

--- a/metrics.go
+++ b/metrics.go
@@ -147,6 +147,9 @@ func (m *metrics) registerInstance() {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Add("UNLEASH-APPNAME", m.options.appName)
+	req.Header.Add("UNLEASH-INSTANCEID", m.options.instanceId)
+	req.Header.Add("User-Agent", m.options.appName)
 
 	resp, err := m.options.httpClient.Do(req)
 	if err != nil {
@@ -237,7 +240,7 @@ func (m *metrics) getPayload() MetricsData {
 func (m metrics) getClientData() ClientData {
 	return ClientData{
 		m.options.appName,
-		m.options.instanceID,
+		m.options.instanceId,
 		m.options.strategies,
 		m.started,
 		int64(m.options.metricsInterval.Seconds()),
@@ -247,7 +250,7 @@ func (m metrics) getClientData() ClientData {
 func (m metrics) getMetricsData() MetricsData {
 	return MetricsData{
 		m.options.appName,
-		m.options.instanceID,
+		m.options.instanceId,
 		m.bucket,
 	}
 }

--- a/metrics.go
+++ b/metrics.go
@@ -194,8 +194,8 @@ func (m *metrics) doPost(url *url.URL, payload interface{}) (*http.Response, err
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Add("Unleash-Appname", m.options.appName)
-	req.Header.Add("Unleash-Instanceid", m.options.instanceId)
+	req.Header.Add("UNLEASH-APPNAME", m.options.appName)
+	req.Header.Add("UNLEASH-INSTANCEID", m.options.instanceId)
 	req.Header.Add("User-Agent", m.options.appName)
 
 	for k, v := range m.options.customHeaders {

--- a/repository.go
+++ b/repository.go
@@ -75,6 +75,10 @@ func (r *repository) fetch() {
 	req.Header.Add("UNLEASH-INSTANCEID", r.options.instanceId)
 	req.Header.Add("User-Agent", r.options.appName)
 
+	for k, v := range r.options.customHeaders {
+		req.Header[k] = v
+	}
+
 	if r.etag != "" {
 		req.Header.Add("If-None-Match", r.etag)
 	}

--- a/repository.go
+++ b/repository.go
@@ -73,6 +73,7 @@ func (r *repository) fetch() {
 
 	req.Header.Add("UNLEASH-APPNAME", r.options.appName)
 	req.Header.Add("UNLEASH-INSTANCEID", r.options.instanceId)
+	req.Header.Add("User-Agent", r.options.appName)
 
 	if r.etag != "" {
 		req.Header.Add("If-None-Match", r.etag)


### PR DESCRIPTION
This pull requests contains a few small fixes around headers. We were not currently setting the `User-Agent` header in the Go client so this fixes that and in addition adds support for custom headers. Also, there was a lot of duplicate code in the metrics class for POSTing to register the client and sending metrics so I factored that out into a separate function that marshals to JSON, sets the correct headers and sends the request.