### PR TITLE
Add support for CIDR ranges in lists of IPs

### DIFF
--- a/internal/strategies/remote_address_test.go
+++ b/internal/strategies/remote_address_test.go
@@ -53,4 +53,14 @@ func TestRemoteAddressStrategy_IsEnabled(t *testing.T) {
 		}
 		assert.True(s.IsEnabled(params, ctx), "RemoteAddressStrategy should be enabled for ip in list")
 	})
+
+	t.Run("r=range(i)", func(t *testing.T) {
+		params := map[string]interface{}{
+			strategy.ParamIps: "127.0.1.1, 127.0.1.2,127.0.1.3, 160.33.0.0/16",
+		}
+		ctx := &context.Context{
+			RemoteAddress: "160.33.0.33",
+		}
+		assert.True(s.IsEnabled(params, ctx), "RemoteAddressStrategy should be enabled for ip inside range in a list")
+	})
 }


### PR DESCRIPTION
This allows the server to use CIDR ranges when specifying the list of
valid IP addresses for a feature. This also improved the testing for
normal IP addresses because now we are parsing them into a proper IP
address struct and using the builtin `Equal` function. This has an
added benefit over pure string matching because if the remote address is
IPv6, we can still potentially match against an IPv4 address or range
and vice versa.

Fixes #13