### PR TITLE
Fix gradualRolloutRandom when percentage is 0

### DIFF
--- a/internal/strategies/gradual_rollout_random.go
+++ b/internal/strategies/gradual_rollout_random.go
@@ -33,5 +33,5 @@ func (s gradualRolloutRandomStrategy) IsEnabled(params map[string]interface{}, _
 		return false
 	}
 
-	return percentage >= float64(s.random.Intn(100))
+	return percentage >= float64(s.random.Intn(100)+1)
 }


### PR DESCRIPTION
In the case where percentage is 0, you would expect that the feature is
always false. However since Intn() can return 0 and the comparison uses
>= it was possible that the feature would be true if the random number
was also 0. This can be fixed by simply adding 1 to ensure we never get
a 0.