### PR TITLE
metrics: Close http response bodies to avoid leaks

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -144,6 +144,7 @@ func (m *metrics) registerInstance() {
 		m.err(err)
 		return
 	}
+	resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
 		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
@@ -172,6 +173,7 @@ func (m *metrics) sendMetrics() {
 		m.err(err)
 		return
 	}
+	resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
 		m.warn(fmt.Errorf("%s return 404, stopping metrics", u.String()))

--- a/metrics.go
+++ b/metrics.go
@@ -144,7 +144,7 @@ func (m *metrics) registerInstance() {
 		m.err(err)
 		return
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
 		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
@@ -173,7 +173,7 @@ func (m *metrics) sendMetrics() {
 		m.err(err)
 		return
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
 		m.warn(fmt.Errorf("%s return 404, stopping metrics", u.String()))


### PR DESCRIPTION
In order to avoid a goroutine leak (the read and write loops on a persistent http connection), we need to close the response body every time.