### PR TITLE
Fix 'WithDisableMetrics' to actually stop sending metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,6 +171,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			url:             *parsedUrl,
 			httpClient:      uc.options.httpClient,
 			customHeaders:   uc.options.customHeaders,
+			disableMetrics:  uc.options.disableMetrics,
 		},
 		metricsChannels{
 			errorChannels: errChannels,

--- a/client.go
+++ b/client.go
@@ -91,6 +91,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		count:         make(chan metric),
 		sent:          make(chan MetricsData),
 		registered:    make(chan ClientData, 1),
+		closed:        make(chan bool),
 	}
 
 	for _, opt := range options {

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
-	gopkg.in/h2non/gock.v1 v1.0.10
+	gopkg.in/h2non/gock.v1 v1.0.12
 )

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,5 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 gopkg.in/h2non/gock.v1 v1.0.10 h1:D4j796HhgidcxF0LnDyFXcoEbEZWoLEWf0kRh61p22w=
 gopkg.in/h2non/gock.v1 v1.0.10/go.mod h1:KHI4Z1sxDW6P4N3DfTWSEza07YpkQP7KJBfglRMEjKY=
+gopkg.in/h2non/gock.v1 v1.0.12 h1:o3JJqe+h7R9Ay6LtMeFrKz1WnokrJDrNpDQs9KGqVn8=
+gopkg.in/h2non/gock.v1 v1.0.12/go.mod h1:KHI4Z1sxDW6P4N3DfTWSEza07YpkQP7KJBfglRMEjKY=

--- a/metrics.go
+++ b/metrics.go
@@ -103,6 +103,10 @@ func (m *metrics) startTimer() {
 }
 
 func (m *metrics) stop() {
+	if m.options.disableMetrics {
+		return
+	}
+
 	if !m.timer.Stop() {
 		<-m.timer.C
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -110,6 +110,9 @@ func (m *metrics) stop() {
 }
 
 func (m *metrics) sync() {
+	if m.options.disableMetrics {
+		return
+	}
 	for {
 		select {
 		case <-m.timer.C:

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -29,12 +29,13 @@ func TestMetrics_RegisterInstance(t *testing.T) {
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 
-	_, err := NewClient(
+	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
+	defer client.Close()
 
 	time.Sleep(1 * time.Second)
 
@@ -62,6 +63,7 @@ func TestMetrics_DoPost(t *testing.T) {
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
 	)
+	defer client.Close()
 
 	assert.Nil(err, "client should not return an error")
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -50,7 +50,14 @@ func TestMetrics_DoPost(t *testing.T) {
 
 	gock.New(mockerServer).
 		Post("/client/register").
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
 
 	gock.New(mockerServer).
 		Post("").
@@ -62,6 +69,7 @@ func TestMetrics_DoPost(t *testing.T) {
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
+		WithListener(&DebugListener{}),
 	)
 	defer client.Close()
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -105,6 +105,7 @@ func TestMetrics_DisabledMetrics(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
+	defer client.Close()
 
 	assert.Nil(err, "client should not return an error")
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -75,3 +75,37 @@ func TestMetrics_DoPost(t *testing.T) {
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
 
+func TestMetrics_DisabledMetrics(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.Off()
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithDisableMetrics(true),
+		WithMetricsInterval(100*time.Millisecond),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+
+	client.IsEnabled("foo")
+	client.IsEnabled("bar")
+	client.IsEnabled("baz")
+
+	time.Sleep(300 * time.Millisecond)
+
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}
+

--- a/repository.go
+++ b/repository.go
@@ -21,6 +21,7 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 	repo := &repository{
 		options:            options,
 		repositoryChannels: channels,
+		close:              make(chan bool),
 	}
 
 	if options.httpClient == nil {


### PR DESCRIPTION
This was previously broken because we were never passing down the
boolean value from the client to the metrics struct. Doing so implies
that the timer is never created so we can't read from the channel in the
sync function. If metrics are disabled, there is really no reason to
even run the metrics routine, so just return instead.

Fixes #15