### PR TITLE
disableMetrics does not actually disable metrics reporting in v3

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,6 +171,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			url:             *parsedUrl,
 			httpClient:      uc.options.httpClient,
 			customHeaders:   uc.options.customHeaders,
+			disableMetrics:  uc.options.disableMetrics,
 		},
 		metricsChannels{
 			errorChannels: errChannels,

--- a/metrics.go
+++ b/metrics.go
@@ -110,6 +110,10 @@ func (m *metrics) stop() {
 }
 
 func (m *metrics) sync() {
+	if m.options.disableMetrics {
+		return
+	}
+
 	for {
 		select {
 		case <-m.timer.C:


### PR DESCRIPTION
Was getting a deadlock in metrics reporting, so I tried to disable metrics but it did not work.  Here is a patch to fix it:

Needed to propagate disableMetrics option from client to the metrics options block to disable metrics from the beginning of execution. Once disabled, `sync()` panics because the timer is not initialized in the case that metrics are disabled, so I added a check to return early when disableMetrics is set.