### PR TITLE
repository: initialize close channel

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ type Client struct {
 	repositoryListener RepositoryListener
 	ready              chan bool
 	onReady            chan bool
-	closed             chan bool
+	closed             chan struct{}
 	count              chan metric
 	sent               chan MetricsData
 	registered         chan ClientData
@@ -91,6 +91,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		count:         make(chan metric),
 		sent:          make(chan MetricsData),
 		registered:    make(chan ClientData, 1),
+		closed:        make(chan struct{}),
 	}
 
 	for _, opt := range options {
@@ -263,7 +264,7 @@ func (uc Client) IsEnabled(feature string, options ...FeatureOption) (enabled bo
 func (uc *Client) Close() error {
 	uc.repository.Close()
 	uc.metrics.Close()
-	uc.closed <- true
+	close(uc.closed)
 	return nil
 }
 

--- a/repository.go
+++ b/repository.go
@@ -14,13 +14,14 @@ type repository struct {
 	sync.RWMutex
 	options repositoryOptions
 	etag    string
-	close   chan bool
+	close   chan struct{}
 }
 
 func newRepository(options repositoryOptions, channels repositoryChannels) *repository {
 	repo := &repository{
 		options:            options,
 		repositoryChannels: channels,
+		close:              make(chan struct{}),
 	}
 
 	if options.httpClient == nil {
@@ -121,6 +122,6 @@ func (r *repository) getToggle(key string) *api.Feature {
 }
 
 func (r *repository) Close() error {
-	r.close <- true
+	close(r.close)
 	return nil
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -70,6 +70,7 @@ func (td TestDefinition) Run(t *testing.T) {
 		client, err := td.Mock()
 		assert.NoError(t, err)
 		t.Run(test.Description, test.RunWithClient(client))
+		client.Close()
 		td.Unmock()
 	}
 }


### PR DESCRIPTION
Also change channel type to struct{} to indicate it's used for
signaling only.

Fixes #48.