### PR TITLE
Make go test -race ./... pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,6 @@ Run code-style checks:(currently failing)
     
     make strict-check
     
-Run race-tests(currently failing):
+Run race-tests:
  
     make test-all

--- a/client.go
+++ b/client.go
@@ -267,8 +267,11 @@ func (uc Client) IsEnabled(feature string, options ...FeatureOption) (enabled bo
 func (uc *Client) Close() error {
 	uc.repository.Close()
 	uc.metrics.Close()
-	close(uc.close)
-	<-uc.closed
+	if uc.options.listener != nil {
+		// Wait for sync to exit.
+		close(uc.close)
+		<-uc.closed
+	}
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -2,11 +2,12 @@ package unleash
 
 import (
 	"fmt"
-	s "github.com/Unleash/unleash-client-go/v3/internal/strategies"
-	"github.com/Unleash/unleash-client-go/v3/strategy"
 	"net/url"
 	"strings"
 	"time"
+
+	s "github.com/Unleash/unleash-client-go/v3/internal/strategies"
+	"github.com/Unleash/unleash-client-go/v3/strategy"
 )
 
 const (
@@ -37,6 +38,7 @@ type Client struct {
 	repositoryListener RepositoryListener
 	ready              chan bool
 	onReady            chan struct{}
+	close              chan struct{}
 	closed             chan struct{}
 	count              chan metric
 	sent               chan MetricsData
@@ -90,6 +92,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		count:         make(chan metric),
 		sent:          make(chan MetricsData),
 		registered:    make(chan ClientData, 1),
+		close:         make(chan struct{}),
 		closed:        make(chan struct{}),
 	}
 
@@ -212,7 +215,8 @@ func (uc *Client) sync() {
 			if uc.metricsListener != nil {
 				uc.metricsListener.OnRegistered(cd)
 			}
-		case <-uc.closed:
+		case <-uc.close:
+			close(uc.closed)
 			return
 		}
 	}
@@ -263,7 +267,8 @@ func (uc Client) IsEnabled(feature string, options ...FeatureOption) (enabled bo
 func (uc *Client) Close() error {
 	uc.repository.Close()
 	uc.metrics.Close()
-	close(uc.closed)
+	close(uc.close)
+	<-uc.closed
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,47 @@
+package unleash
+
+import (
+	"testing"
+
+	"github.com/Unleash/unleash-client-go/v3/internal/api"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestClientWithoutListener(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		Reply(200)
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	go func() {
+		for {
+			select {
+			case e := <-client.Errors():
+				t.Fatalf("Unexpected error: %v", e)
+			case w := <-client.Warnings():
+				t.Fatalf("Unexpected warning: %v", w)
+			case <-client.Count():
+			case <-client.Sent():
+			}
+		}
+	}()
+	<-client.Registered()
+	<-client.Ready()
+	client.Close()
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}

--- a/metrics.go
+++ b/metrics.go
@@ -106,8 +106,8 @@ func (m *metrics) Close() error {
 		m.cancel()
 		close(m.close)
 		m.options.disableMetrics = true
+		<-m.closed
 	}
-	<-m.closed
 	return nil
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -105,7 +105,6 @@ func (m *metrics) Close() error {
 		m.timer.Stop()
 		m.cancel()
 		close(m.close)
-		m.options.disableMetrics = true
 		<-m.closed
 	}
 	return nil

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -87,3 +87,35 @@ func TestMetrics_DoPost(t *testing.T) {
 	assert.Equal(200, res.StatusCode, "statusCode should be 200")
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
+
+func TestMetrics_DisabledMetrics(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithDisableMetrics(true),
+		WithMetricsInterval(100*time.Millisecond),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+	client.IsEnabled("foo")
+	client.IsEnabled("bar")
+	client.IsEnabled("baz")
+
+	time.Sleep(300 * time.Millisecond)
+	client.Close()
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}


### PR DESCRIPTION
This PR makes Client.Close return *after* all resources have been freed
that's used by the client. In particular, when Client.Close returns all
goroutines started by the client have exited, any errors and warnings reported
by the client have been sent to their respective channels or listeners, and no
HTTP requests started by the client will still be in flight.

https://github.com/Unleash/unleash-client-go/issues/17 isn't fixed by this change, but I believe it's a step in the right direction.