### PR TITLE
Detect data races in Client.IsEnabled in tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -222,7 +222,9 @@ func (uc *Client) sync() {
 	}
 }
 
-// IsEnabled queries whether or not the specified feature is enabled or not.
+// IsEnabled queries whether the specified feature is enabled or not.
+//
+// It is safe to call this method from multiple goroutines concurrently.
 func (uc Client) IsEnabled(feature string, options ...FeatureOption) (enabled bool) {
 	defer func() {
 		uc.metrics.count(feature, enabled)
@@ -319,6 +321,8 @@ func (uc Client) getStrategy(name string) strategy.Strategy {
 
 // WaitForReady will block until the internal repository has loaded the feature toggles from the
 // storage engine. It will return immediately if the repository is already ready.
+//
+// It is safe to call this method from multiple goroutines concurrently.
 func (uc *Client) WaitForReady() {
 	<-uc.onReady
 }


### PR DESCRIPTION
This PR makes `go test -race ./...` fail with
```
--- FAIL: TestClientSpecificationSuite (0.12s)
    --- FAIL: TestClientSpecificationSuite/TestClientSpecification (0.11s)
        --- FAIL: TestClientSpecificationSuite/TestClientSpecification/05-gradual-rollout-random-strategy (0.01s)
            --- FAIL: TestClientSpecificationSuite/TestClientSpecification/05-gradual-rollout-random-strategy/Feature.A5_should_be_enabled (0.00s)
                testing.go:809: race detected during execution of test
            testing.go:809: race detected during execution of test
        testing.go:809: race detected during execution of test
    testing.go:809: race detected during execution of test
FAIL
```
The detected data race is fixed in https://github.com/Unleash/unleash-client-go/pull/56 and by adding the relevant parts of that PR on top of this one `go test -race ./...` pass.

This PR also documents that Client.IsEnabled and Client.WaitForReady are safe to use from multiple goroutines concurrently.

Obviously, this PR should not be merged before https://github.com/Unleash/unleash-client-go/pull/56 has been merged.