### PR TITLE
internal/strategies: use plain string concatenation in normalizedValue

### DIFF
--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -1,7 +1,6 @@
 package strategies
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"strconv"
@@ -52,11 +51,10 @@ func parameterAsFloat64(param interface{}) (result float64, ok bool) {
 }
 
 func normalizedValue(id string, groupId string) uint32 {
-	value := fmt.Sprintf("%s:%s", groupId, id)
 	hash := murmur3.New32()
-	hash.Write([]byte(value))
+	hash.Write([]byte(groupId + ":" + id))
 	hashCode := hash.Sum32()
-	return hashCode % uint32(100) + 1
+	return hashCode%uint32(100) + 1
 }
 
 // coalesce returns the first non-empty string in the list of arguments

--- a/internal/strategies/helpers_test.go
+++ b/internal/strategies/helpers_test.go
@@ -1,10 +1,12 @@
 package strategies
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
+	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResolveHostname(t *testing.T) {
@@ -87,4 +89,34 @@ func TestNewRng(t *testing.T) {
 		go testGen(100)
 	}
 	wg.Wait()
+}
+
+func BenchmarkNormalizedValue(b *testing.B) {
+	// Add two sub-benchmarks since the compiler allows
+	// strings and byte slices up to 32 bytes to be allocated
+	// on the stack when they do not escape.
+
+	const (
+		smallId    = "1234567"
+		smallGroup = "group42"
+	)
+
+	var (
+		largeId    = strings.Repeat("a", 16)
+		largeGroup = strings.Repeat("b", 16)
+	)
+
+	b.Run("value less than 32 bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = normalizedValue(smallId, smallGroup)
+		}
+	})
+
+	b.Run("value greater than 32 bytes", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = normalizedValue(largeId, largeGroup)
+		}
+	})
 }


### PR DESCRIPTION
Simple string concatenation provides the best performance when the
number of substrings is "statically" known (as for this case).

Go 1.13.3. Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz.

```
name                                            old time/op    new time/op    delta
NormalizedValue/value_less_than_32_bytes-12        305ns ± 4%     150ns ± 8%  -50.78%  (p=0.000 n=9+9)
NormalizedValue/value_greater_than_32_bytes-12     351ns ±12%     243ns ±11%  -30.90%  (p=0.000 n=10+10)

name                                            old alloc/op   new alloc/op   delta
NormalizedValue/value_less_than_32_bytes-12         144B ± 0%       96B ± 0%  -33.33%  (p=0.000 n=10+10)
NormalizedValue/value_greater_than_32_bytes-12      208B ± 0%      176B ± 0%  -15.38%  (p=0.000 n=10+10)

name                                            old allocs/op  new allocs/op  delta
NormalizedValue/value_less_than_32_bytes-12         5.00 ± 0%      2.00 ± 0%  -60.00%  (p=0.000 n=10+10)
NormalizedValue/value_greater_than_32_bytes-12      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
```