### PR TITLE
Cleanup Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,28 @@
 SHELL := /bin/bash
 
-# The name of the executable (default is current directory name)
-TARGET := $(shell echo $${PWD\#\#*/})
-.DEFAULT_GOAL: $(TARGET)
+# go source files, ignore testdata directory
+SRC = $(shell find . -type f -name '*.go' -not -path './testdata/*')
 
-# These will be provided to the target
-VERSION := 1.0.0
-BUILD := `git rev-parse HEAD`
-
-# go source files, ignore vendor directory
-SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
-
-.PHONY: all build clean install uninstall fmt simplify check run
+.PHONY: all fmt fmt-check vet check strict-check test test-race
 
 all: test
-
-$(TARGET): $(SRC)
-	go build -o $(TARGET)
-
-build: $(TARGET)
-	@true
-
-clean:
-	rm -f $(TARGET)
 
 fmt:
 	gofmt -l -w $(SRC)
 
-test: get-deps
-	go test -short ./...
+fmt-check:
+	test -z $$(gofmt -l $(SRC))
 
-lint:
+vet:
 	go vet ./...
 
-test-all: lint test
+check: fmt-check vet
+
+strict-check: check
+	golint ./...
+
+test: check
+	go test ./...
+
+test-race: check
 	go test -race ./...
-
-strict-check:
-	@test -z $(shell gofmt -l main.go | tee /dev/stderr) || echo "[WARN] Fix formatting issues with 'make fmt'"
-	@for d in $$(go list ./... | grep -v /vendor/); do golint $${d}; done
-	@go tool vet ${SRC}
-
-get-deps:
-	go get -t ./...
-
-run: test-all install
-	@$(TARGET)


### PR DESCRIPTION
I would be happy to remove the `$(TARGET)`, `build`, and `clean` targets as well. Are they used for anything?
