### PR TITLE
Parse features from schema file into Feature struct

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/Unleash/unleash-client-go/v3/api"
 )
 
 // Storage is an interface that can be implemented in order to have control over how
@@ -60,8 +62,13 @@ func (ds *defaultStorage) Load() error {
 		return err
 	} else {
 		dec := json.NewDecoder(file)
-		if err := dec.Decode(&ds.data); err != nil {
+		var featuresFromFile map[string]api.Feature
+		if err := dec.Decode(&featuresFromFile); err != nil {
 			return err
+		}
+
+		for key, value := range featuresFromFile {
+			ds.data[key] = value
 		}
 	}
 	return nil


### PR DESCRIPTION
This is a possible fix for issue #82

The features read from file will be parsed into a `map[string]api.Feature`, then
copied over to the `data` property of the `defaultStorage` struct.
This way they can be cast correctly to a feature when read in `repository.getToggle()`.