### PR TITLE
feat: Implement custom stickiness for FlexibleRollout and variants

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -76,7 +76,9 @@ func (f Feature) getVariantFromWeights(ctx *context.Context) *Variant {
 		return DISABLED_VARIANT
 	}
 
-	target := getNormalizedNumber(getSeed(ctx), f.Name, totalWeight)
+	stickiness := f.Variants[0].Stickiness
+
+	target := getNormalizedNumber(getSeed(ctx, stickiness), f.Name, totalWeight)
 	counter := uint32(0)
 	for _, variant := range f.Variants {
 		counter += uint32(variant.Weight)
@@ -100,7 +102,17 @@ func (f Feature) getOverrideVariant(ctx *context.Context) *VariantInternal {
 	return nil
 }
 
-func getSeed(ctx *context.Context) string {
+func getSeed(ctx *context.Context, stickiness string) string {
+	if stickiness != "default" && stickiness != "" {
+		value := ctx.Field(stickiness)
+
+		if value == "" {
+			return strconv.Itoa(rand.Intn(10000))
+		}
+
+		return value
+	}
+
 	if ctx.UserId != "" {
 		return ctx.UserId
 	} else if ctx.SessionId != "" {

--- a/api/variant.go
+++ b/api/variant.go
@@ -36,6 +36,7 @@ type VariantInternal struct {
 	Weight int `json:"weight"`
 	// WeightType can be fixed or variable
 	WeightType string `json:"weightType"`
+	Stickiness string `json:"stickiness"`
 	// Override is used to get a variant accoording to the Unleash context field
 	Overrides []Override `json:"overrides"`
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -19,7 +19,7 @@ const mockHost = "http://unleash-apu"
 const specFolder = "./testdata/client-specification/specifications"
 
 var specIndex = filepath.Join(specFolder, "index.json")
-var specNotImplemented = []string{"12-custom-stickiness"}
+var specNotImplemented = []string{}
 
 type TestState struct {
 	Version  int           `json:"version"`


### PR DESCRIPTION
There is some duplication in field matching and coalescing, but I chose not to address it in this PR this since the duplication was existing.

I chose to implement both features in a single PR since the changes were fairly small. Implementing in a single PR allows enabling the full spec test.

Implements https://github.com/Unleash/unleash-client-go/issues/80
Implements https://github.com/Unleash/unleash-client-go/issues/81