### PR TITLE
fix: empty userWithIdStrategy case

### DIFF
--- a/internal/strategies/user_with_id.go
+++ b/internal/strategies/user_with_id.go
@@ -23,7 +23,7 @@ func (s userWithIdStrategy) IsEnabled(params map[string]interface{}, ctx *contex
 	}
 
 	userIds, ok := value.(string)
-	if !ok {
+	if !ok || userIds == "" {
 		return false
 	}
 

--- a/internal/strategies/user_with_id_test.go
+++ b/internal/strategies/user_with_id_test.go
@@ -55,4 +55,11 @@ func TestUserWithIdStrategy_IsEnabled(t *testing.T) {
 		}
 		assert.True(s.IsEnabled(params, ctx), "user-with-id-strategy should be enabled for userId in list")
 	})
+	t.Run("u=empty", func(t *testing.T) {
+		params := map[string]interface{}{
+			strategy.ParamUserIds: "",
+		}
+		ctx := &context.Context{}
+		assert.False(s.IsEnabled(params, ctx), "user-with-id-strategy should not be enabled for empty strategy")
+	})
 }


### PR DESCRIPTION
 I'm new to Unleash, so my apologies if this pull request turns out to be nonsensical.

`IsEnabled` returns true for an empty UserIdStrategy when `UserId` is missing from the context. The reason is that `strings.Split` for an empty string returns `[""]`, giving the `userId` comparison loop a chance to both run _and_ find a match.