### PR TITLE
docs: mention default intervals

### DIFF
--- a/config.go
+++ b/config.go
@@ -70,7 +70,7 @@ func WithUrl(url string) ConfigOption {
 }
 
 // WithRefreshInterval specifies the time interval with which the client should sync the
-// feature toggles from the unleash server.
+// feature toggles from the unleash server (default 15s).
 func WithRefreshInterval(refreshInterval time.Duration) ConfigOption {
 	return func(o *configOption) {
 		o.refreshInterval = refreshInterval
@@ -78,7 +78,7 @@ func WithRefreshInterval(refreshInterval time.Duration) ConfigOption {
 }
 
 // WithMetricsInterval specifies the time interval with which the client should upload
-// the metrics data to the unleash server.
+// the metrics data to the unleash server (default 60s).
 func WithMetricsInterval(metricsInterval time.Duration) ConfigOption {
 	return func(o *configOption) {
 		o.metricsInterval = metricsInterval


### PR DESCRIPTION
It's currently not obvious from the documentation if they should call `WithInterval`/`WithMetricsInterval` or if the default values are appropriate for the consumer. Mentioning these defaults should make this a bit more straightforward.

This is the work of @costela, but I managed to merge it to master instead of v3, this just moves the commit