### PR TITLE
Adding option to query for environment

### DIFF
--- a/client.go
+++ b/client.go
@@ -159,6 +159,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			url:             *parsedUrl,
 			appName:         uc.options.appName,
 			projectName:     uc.options.projectName,
+			environment:     uc.options.environment,
 			instanceId:      uc.options.instanceId,
 			refreshInterval: uc.options.refreshInterval,
 			storage:         uc.options.storage,

--- a/config.go
+++ b/config.go
@@ -234,6 +234,7 @@ type repositoryOptions struct {
 	appName         string
 	instanceId      string
 	projectName     string
+	environment     string
 	url             url.URL
 	backupPath      string
 	refreshInterval time.Duration

--- a/repository.go
+++ b/repository.go
@@ -86,7 +86,7 @@ func (r *repository) sync() {
 }
 
 func (r *repository) fetch() error {
-	u, _ := r.options.url.Parse(getFetchURLPath(r.options.projectName))
+	u, _ := r.options.url.Parse(getFetchURLPath(r.options.projectName, r.options.environment))
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package unleash
 import (
 	"fmt"
 	"math/rand"
+	"net/url"
 	"os"
 	"os/user"
 	"time"
@@ -28,9 +29,20 @@ func generateInstanceId() string {
 	return prefix
 }
 
-func getFetchURLPath(projectName string) string {
+func getFetchURLPath(projectName, environment string) string {
+	u, _ := url.Parse("./client/features")
+
+	q := u.Query()
+
 	if projectName != "" {
-		return fmt.Sprintf("./client/features?project=%s", projectName)
+		q.Set("project", projectName)
 	}
-	return "./client/features"
+
+	if environment != "" {
+		q.Set("environment", environment)
+	}
+
+	u.RawQuery = q.Encode()
+
+	return u.String()
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -9,9 +9,12 @@ import (
 // TestGetFetchURLPath verifies that getFetchURLPath returns the correct path
 func TestGetFetchURLPath(t *testing.T) {
 	assert := assert.New(t)
-	res := getFetchURLPath("")
+	res := getFetchURLPath("", "")
 	assert.Equal("./client/features", res)
 
-	res = getFetchURLPath("myProject")
+	res = getFetchURLPath("myProject", "")
 	assert.Equal("./client/features?project=myProject", res)
+
+	res = getFetchURLPath("myProject", "development")
+	assert.Equal("./client/features?environment=development&project=myProject", res)
 }


### PR DESCRIPTION
This PR fix will add the environment variable to the http request when querying for feature for endpoint `api/client/features`. 
At the moment the endpoint  would only query for the project name. With passing in the environment to the query string i am able to toggle IsEnabled true|false for a feature for development environment.