### PR TITLE
fix: avoid panic when not initialized

### DIFF
--- a/unleash.go
+++ b/unleash.go
@@ -37,6 +37,9 @@ type RepositoryListener interface {
 
 // IsEnabled queries the default client whether or not the specified feature is enabled or not.
 func IsEnabled(feature string, options ...FeatureOption) bool {
+	if defaultClient == nil {
+		return false
+	}
 	return defaultClient.IsEnabled(feature, options...)
 }
 
@@ -47,11 +50,17 @@ func Initialize(options ...ConfigOption) (err error) {
 }
 
 func GetVariant(feature string, options ...VariantOption) *api.Variant {
+	if defaultClient == nil {
+		return api.GetDefaultVariant()
+	}
 	return defaultClient.GetVariant(feature, options...)
 }
 
 // Close will close the default client.
 func Close() error {
+	if defaultClient == nil {
+		return nil
+	}
 	return defaultClient.Close()
 }
 


### PR DESCRIPTION
## About the changes
Using `IsEnabled` withoug initialization currently panics with a nil deref.

This change eases e.g. integration of unleash in frameworks, allowing optional initialization.

Consumers already have to deal with the fact that the unleash server may be unreachable during a deployment, so even if the initialization works, to be defensive one must assume a _disabled_ feature flag is less harmful than a panicking service. 

