### PR TITLE
force getVariant to also add to the feature toggle metrics counter

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -351,6 +351,7 @@ func TestClientWithVariantContext(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -854,6 +855,7 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError").Return()
 

--- a/metrics.go
+++ b/metrics.go
@@ -230,11 +230,13 @@ func (m *metrics) count(name string, enabled bool) {
 	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
 }
 
-func (m *metrics) countVariants(name string, variantName string) {
+func (m *metrics) countVariants(name string, enabled bool, variantName string) {
 	if m.options.disableMetrics {
 		return
 	}
 
+	m.add(name, enabled, 1)
+	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
 	t, _ := m.bucket.Toggles[name]
 	if len(t.Variants) == 0 {
 		t.Variants = make(map[string]int32)


### PR DESCRIPTION
This forces resolving a variant to correctly add to the feature toggle counter metrics. Also fixes an issue where variants wouldn't get counted for the default/disabled case (brings this SDK inline with the behaviour of its siblings)