### PR TITLE
Docs: update doc links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ provided by unleash.
 - RemoteAddressStrategy
 - ApplicationHostnameStrategy
 
-[Read more about activation strategies in the docs](https://docs.getunleash.io/user_guide/activation_strategy).
+[Read more about activation strategies in the docs](https://docs.getunleash.io/reference/activation-strategies).
 
 ### Unleash context
 
 In order to use some of the common activation strategies you must provide an
-[unleash-context](https://docs.getunleash.io/user_guide/unleash_context).
+[unleash-context](https://docs.getunleash.io/reference/unleash-context).
 This client SDK allows you to send in the unleash context as part of the `isEnabled` call:
 
 ```go


### PR DESCRIPTION
Replace old doc links with their current version. The redirects should still work, but doing it this way makes it nicer in the UI (plus getting rid of old links is just nice)