### PR TITLE
fix: make variant metrics concurrency safe

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -237,6 +237,10 @@ func (m *metrics) countVariants(name string, enabled bool, variantName string) {
 
 	m.add(name, enabled, 1)
 	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+
+	m.bucketMu.Lock()
+	defer m.bucketMu.Unlock()
+
 	t, _ := m.bucket.Toggles[name]
 	if len(t.Variants) == 0 {
 		t.Variants = make(map[string]int32)


### PR DESCRIPTION
This adds a mutex lock to the metrics for `GetVariant`, which fixes a crash bug which occurs when the `GetVariant`` method is called in a tight loop concurrently.

The toggle data that's modified in the `countVariants`  is bound to the bucket, which is locked by the mutex, so I want to say this safe.

I haven't added a test because concurrency reasons but this can be arbitrarily reproduced with the following hacky code snippet from version 3.2.x to 3.7.2 (doesn't occur with equivalent `IsEnabled` calls).

``` go
timer := time.NewTimer(1 * time.Second)

for {
	<-timer.C

	go func() {
		for i := 0; i < 10000; i++ {
			variant := unleash.GetVariant("test")
			fmt.Printf("'%s' enabled? %v\n", "test", variant)
			timer.Reset(1 * time.Second)
		}
	}()

	go func() {
		for i := 0; i < 10000; i++ {
			variant := unleash.GetVariant("test")
			fmt.Printf("'%s' enabled? %v\n", "test", variant)
			timer.Reset(1 * time.Second)
		}
	}()
}

```