### PR TITLE
fix: patch random stickiness calculations for rollout strategies

### DIFF
--- a/internal/strategies/flexible_rollout_test.go
+++ b/internal/strategies/flexible_rollout_test.go
@@ -1,0 +1,32 @@
+package strategies
+
+import (
+	"testing"
+
+	"github.com/Unleash/unleash-client-go/v3/context"
+	"github.com/Unleash/unleash-client-go/v3/strategy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlexibleRolloutStrategy_IsWellDistributed(t *testing.T) {
+	s := NewFlexibleRolloutStrategy()
+
+	enabledCount := 0
+	rounds := 200000
+
+	for i := 0; i < rounds; i++ {
+		params := map[string]interface{}{
+			strategy.ParamStickiness: "random",
+			strategy.ParamRollout:    50,
+			strategy.ParamGroupId:    "test51",
+		}
+		enabled := s.IsEnabled(params, &context.Context{})
+		if enabled {
+			enabledCount++
+		}
+	}
+
+	actualPercentage := round(100.0 * float64(enabledCount) / float64(rounds))
+
+	assert.InDelta(t, 50, actualPercentage, 1.0)
+}

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -84,7 +84,10 @@ func (r *rng) float() float64 {
 }
 
 func (r *rng) string() string {
-	return strconv.Itoa(r.int())
+	r.Lock()
+	n := r.random.Intn(10000) + 1
+	r.Unlock()
+	return strconv.Itoa(n)
 }
 
 // newRng creates a new random number generator for numbers between 1-100

--- a/internal/strategies/helpers_test.go
+++ b/internal/strategies/helpers_test.go
@@ -75,7 +75,7 @@ func TestNewRng(t *testing.T) {
 			assert.True(t, randomInt >= 0 && randomInt <= 100)
 
 			randomString := rng.string()
-			assert.True(t, len(randomString) <= 3)
+			assert.True(t, len(randomString) <= 5)
 
 			randomFloat := rng.float()
 			assert.True(t, randomFloat > 0.0 && randomFloat <= 100.0)


### PR DESCRIPTION
This patches the source of randomness in the % rollout calculations. Previously this was using a number between 0 and 100 (other SDKs use 0 to 10 000). This means pidgeon holing the calculation becomes much, much more likely and certain strings used as a toggle name produce very non uniform rollout distributions