### PR TITLE
Use fallback value if client is not initialized

### DIFF
--- a/unleash.go
+++ b/unleash.go
@@ -38,7 +38,11 @@ type RepositoryListener interface {
 // IsEnabled queries the default client whether or not the specified feature is enabled or not.
 func IsEnabled(feature string, options ...FeatureOption) bool {
 	if defaultClient == nil {
-		return false
+		var opts featureOption
+		for _, o := range options {
+			o(&opts)
+		}
+		return handleFallback(opts, feature, opts.ctx).Enabled
 	}
 	return defaultClient.IsEnabled(feature, options...)
 }

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -64,3 +64,10 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 		t.Fatalf("Expected feature to be disabled because Environment does not exist as strategy")
 	}
 }
+
+func Test_IsEnabledWithUninitializedClient(t *testing.T) {
+	result := unleash.IsEnabled("foo", unleash.WithFallback(true))
+	if !result {
+		t.Fatalf("Expected true")
+	}
+}


### PR DESCRIPTION
## About the changes
If no defaultClient is initialized, we should return the provided fallback value instead of `false`.