### PR TITLE
fix: default to a noop listener to avoid hanging on channel messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ unleash.IsEnabled("someToggle", unleash.WithContext(ctx), unleash.WithResolver(r
 
 ## Development
 
+To override dependency on unleash-client-go github repository to a local development folder (for instance when building a local test-app for the SDK),  
+you can add the following to your apps `go.mod`:
+
+```mod
+    replace github.com/Unleash/unleash-client-go/v3 => ../unleash-client-go/
+```
+
+
+
 ## Steps to release
 
 - Update the clientVersion in `client.go`

--- a/client.go
+++ b/client.go
@@ -112,20 +112,22 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		AppName:     uc.options.appName,
 	}
 
-	if uc.options.listener != nil {
-		if eListener, ok := uc.options.listener.(ErrorListener); ok {
-			uc.errorListener = eListener
-		}
-		if rListener, ok := uc.options.listener.(RepositoryListener); ok {
-			uc.repositoryListener = rListener
-		}
-		if mListener, ok := uc.options.listener.(MetricListener); ok {
-			uc.metricsListener = mListener
-		}
-		defer func() {
-			go uc.sync()
-		}()
+	if uc.options.listener == nil {
+		uc.options.listener = &NoopListener{}
 	}
+
+	if eListener, ok := uc.options.listener.(ErrorListener); ok {
+		uc.errorListener = eListener
+	}
+	if rListener, ok := uc.options.listener.(RepositoryListener); ok {
+		uc.repositoryListener = rListener
+	}
+	if mListener, ok := uc.options.listener.(MetricListener); ok {
+		uc.metricsListener = mListener
+	}
+	defer func() {
+		go uc.sync()
+	}()
 
 	if uc.options.url == "" {
 		return nil, fmt.Errorf("Unleash server URL missing")

--- a/nooplistener.go
+++ b/nooplistener.go
@@ -1,0 +1,31 @@
+package unleash
+
+// DebugListener is an implementation of all of the listener interfaces that simply logs
+// debug info to stdout. It is meant for debugging purposes and an example of implementing
+// the listener interfaces.
+type NoopListener struct{}
+
+/*
+// OnError prints out errors.
+func (l NoopListener) OnError(err error) {
+}
+
+// OnWarning prints out warning.
+func (l NoopListener) OnWarning(warning error) {
+}
+
+// OnReady prints to the console when the repository is ready.
+func (l NoopListener) OnReady() {
+}
+
+// OnCount prints to the console when the feature is queried.
+func (l NoopListener) OnCount(name string, enabled bool) {
+}
+// OnSent prints to the console when the server has uploaded metrics.
+func (l NoopListener) OnSent(payload MetricsData) {
+}
+
+// OnRegistered prints to the console when the client has registered.
+func (l NoopListener) OnRegistered(payload ClientData) {
+}
+*/

--- a/nooplistener.go
+++ b/nooplistener.go
@@ -1,31 +1,28 @@
 package unleash
 
-// DebugListener is an implementation of all of the listener interfaces that simply logs
-// debug info to stdout. It is meant for debugging purposes and an example of implementing
-// the listener interfaces.
+// NoopListener is an implementation of all of the listener interfaces that discards
+// all messages. It's added if no other listener is added to drain the channels and as
+// an example of implementing the listener interfaces.
 type NoopListener struct{}
 
-/*
-// OnError prints out errors.
 func (l NoopListener) OnError(err error) {
 }
 
-// OnWarning prints out warning.
 func (l NoopListener) OnWarning(warning error) {
 }
 
-// OnReady prints to the console when the repository is ready.
+// The repository is ready.
 func (l NoopListener) OnReady() {
 }
 
-// OnCount prints to the console when the feature is queried.
+// The feature is queried.
 func (l NoopListener) OnCount(name string, enabled bool) {
 }
-// OnSent prints to the console when the server has uploaded metrics.
+
+// The server has uploaded metrics.
 func (l NoopListener) OnSent(payload MetricsData) {
 }
 
-// OnRegistered prints to the console when the client has registered.
+// The client has registered.
 func (l NoopListener) OnRegistered(payload ClientData) {
 }
-*/

--- a/nooplistener_test.go
+++ b/nooplistener_test.go
@@ -1,0 +1,24 @@
+package unleash
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_defaultsToNoopListener(t *testing.T) {
+	result := Initialize(
+		WithAppName("my-application"),
+		WithUrl("http://localhost:4242"),
+		WithCustomHeaders(http.Header{"Authorization": {"*:development.code"}}),
+	)
+
+	if result != nil {
+		t.Fail()
+	}
+	res := IsEnabled("test", WithFallback(false))
+	assert.Equal(t, false, res)
+
+	assert.IsType(t, &NoopListener{}, defaultClient.errorListener)
+}


### PR DESCRIPTION
## About the changes

Defaults to register a NoopListener if no listener has been added

Closes #139

## Discussion points

Should this also actually listen to the individual channels? I have commented that part out and seems to work without it but I'm unsure if this has longer term effects