### PR TITLE
fix: new variant hashing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         name: Checkout client specifications
         with:
           repository: Unleash/client-specification
-          ref: refs/tags/v4.3.1
+          ref: refs/tags/v5.0.0
           path: testdata/client-specification
       - uses: actions/setup-go@v2
         name: Setup go

--- a/api/feature.go
+++ b/api/feature.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"fmt"
 	"math/rand"
 	"strconv"
 	"time"
 
 	"github.com/Unleash/unleash-client-go/v3/context"
 	"github.com/Unleash/unleash-client-go/v3/internal/strategies"
-	"github.com/twmb/murmur3"
 )
 
 type ParameterMap map[string]interface{}
@@ -148,8 +146,4 @@ func getSeed(ctx *context.Context, stickiness string) string {
 		return ctx.RemoteAddress
 	}
 	return strconv.Itoa(rand.Intn(10000))
-}
-
-func getNormalizedNumber(identifier, groupId string, normalizer int) uint32 {
-	return (murmur3.Sum32([]byte(fmt.Sprintf("%s:%s", groupId, identifier))) % uint32(normalizer)) + 1
 }

--- a/api/feature.go
+++ b/api/feature.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Unleash/unleash-client-go/v3/context"
+	"github.com/Unleash/unleash-client-go/v3/internal/strategies"
 	"github.com/twmb/murmur3"
 )
 
@@ -105,7 +106,7 @@ func (vc VariantCollection) getVariantFromWeights(ctx *context.Context) *Variant
 	}
 	stickiness := vc.Variants[0].Stickiness
 
-	target := getNormalizedNumber(getSeed(ctx, stickiness), vc.GroupId, totalWeight)
+	target := strategies.NormalizedVariantValue(getSeed(ctx, stickiness), vc.GroupId, totalWeight, strategies.VariantNormalizationSeed)
 	counter := uint32(0)
 	for _, variant := range vc.Variants {
 		counter += uint32(variant.Weight)

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -255,7 +255,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarF() {
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
 	}.GetVariant(mockContext)
-	suite.Equal("VarF", variantSetup.Name, "Should return VarF")
+	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
 

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -238,7 +238,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarE() {
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
 	}.GetVariant(mockContext)
-	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
+	suite.Equal("VarF", variantSetup.Name, "Should return VarF")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
 

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -221,7 +221,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarD() {
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
 	}.GetVariant(mockContext)
-	suite.Equal("VarD", variantSetup.Name, "Should return VarD")
+	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
 

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 const (
 	deprecatedSuffix = "/features"
 	clientName       = "unleash-client-go"
-	clientVersion    = "3.9.0"
+	clientVersion    = "4.0.0-beta.1"
 )
 
 var defaultStrategies = []strategy.Strategy{

--- a/internal/strategies/flexible_rollout.go
+++ b/internal/strategies/flexible_rollout.go
@@ -62,6 +62,6 @@ func (s flexibleRolloutStrategy) IsEnabled(params map[string]interface{}, ctx *c
 		return false
 	}
 
-	normalizedID := normalizedValue(stickinessID, groupID)
+	normalizedID := normalizedRolloutValue(stickinessID, groupID)
 	return percentage > 0 && float64(normalizedID) <= percentage
 }

--- a/internal/strategies/gradual_rollout_session_id.go
+++ b/internal/strategies/gradual_rollout_session_id.go
@@ -38,7 +38,7 @@ func (s gradualRolloutSessionId) IsEnabled(params map[string]interface{}, ctx *c
 		return false
 	}
 
-	normalizedId := normalizedValue(ctx.SessionId, groupId)
+	normalizedId := normalizedRolloutValue(ctx.SessionId, groupId)
 
 	return percentage > 0.0 && float64(normalizedId) <= percentage
 }

--- a/internal/strategies/gradual_rollout_session_id_test.go
+++ b/internal/strategies/gradual_rollout_session_id_test.go
@@ -42,7 +42,7 @@ func TestGradualRolloutSessionId_IsEnabled(t *testing.T) {
 	t.Run("p1=p2", func(t *testing.T) {
 		sessionId := "123123"
 		groupId := "group1"
-		percentage := normalizedValue(sessionId, groupId)
+		percentage := normalizedRolloutValue(sessionId, groupId)
 
 		params := map[string]interface{}{
 			strategy.ParamPercentage: percentage,
@@ -57,7 +57,7 @@ func TestGradualRolloutSessionId_IsEnabled(t *testing.T) {
 	t.Run("p1<p2", func(t *testing.T) {
 		sessionId := "123123"
 		groupId := "group1"
-		percentage := normalizedValue(sessionId, groupId) - 1
+		percentage := normalizedRolloutValue(sessionId, groupId) - 1
 
 		params := map[string]interface{}{
 			strategy.ParamPercentage: percentage,

--- a/internal/strategies/gradual_rollout_user_id.go
+++ b/internal/strategies/gradual_rollout_user_id.go
@@ -38,7 +38,7 @@ func (s gradualRolloutUserId) IsEnabled(params map[string]interface{}, ctx *cont
 		return false
 	}
 
-	normalizedId := normalizedValue(ctx.UserId, groupId)
+	normalizedId := normalizedRolloutValue(ctx.UserId, groupId)
 
 	return percentage > 0.0 && float64(normalizedId) <= percentage
 }

--- a/internal/strategies/gradual_rollout_user_id_test.go
+++ b/internal/strategies/gradual_rollout_user_id_test.go
@@ -43,7 +43,7 @@ func TestGradualRolloutUserId_IsEnabled(t *testing.T) {
 	t.Run("p1=p2", func(t *testing.T) {
 		userId := "123123"
 		groupId := "group1"
-		percentage := normalizedValue(userId, groupId)
+		percentage := normalizedRolloutValue(userId, groupId)
 
 		params := map[string]interface{}{
 			strategy.ParamPercentage: percentage,
@@ -58,7 +58,7 @@ func TestGradualRolloutUserId_IsEnabled(t *testing.T) {
 	t.Run("p1<p2", func(t *testing.T) {
 		userId := "123123"
 		groupId := "group1"
-		percentage := normalizedValue(userId, groupId) - 1
+		percentage := normalizedRolloutValue(userId, groupId) - 1
 
 		params := map[string]interface{}{
 			strategy.ParamPercentage: percentage,

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/twmb/murmur3"
 )
 
+var VariantNormalizationSeed uint32 = 86028157
+
 func round(f float64) int {
 	if f < -0.5 {
 		return int(f - 0.5)
@@ -50,11 +52,15 @@ func parameterAsFloat64(param interface{}) (result float64, ok bool) {
 	return
 }
 
-func normalizedValue(id string, groupId string) uint32 {
-	hash := murmur3.New32()
+func normalizedRolloutValue(id string, groupId string) uint32 {
+	return NormalizedVariantValue(id, groupId, 100, 0)
+}
+
+func NormalizedVariantValue(id string, groupId string, normalizer int, seed uint32) uint32 {
+	hash := murmur3.SeedNew32(seed)
 	hash.Write([]byte(groupId + ":" + id))
 	hashCode := hash.Sum32()
-	return hashCode%uint32(100) + 1
+	return hashCode%uint32(normalizer) + 1
 }
 
 // coalesce returns the first non-empty string in the list of arguments

--- a/internal/strategies/helpers_test.go
+++ b/internal/strategies/helpers_test.go
@@ -53,9 +53,14 @@ func TestParameterAsFloat64(t *testing.T) {
 	}
 }
 
-func TestNormalizedValue(t *testing.T) {
-	assert.Equal(t, uint32(73), normalizedValue("123", "gr1"))
-	assert.Equal(t, uint32(25), normalizedValue("999", "groupX"))
+func TestNormalizedRolloutValue(t *testing.T) {
+	assert.Equal(t, uint32(73), normalizedRolloutValue("123", "gr1"))
+	assert.Equal(t, uint32(25), normalizedRolloutValue("999", "groupX"))
+}
+
+func TestNormalizedVariantValue(t *testing.T) {
+	assert.Equal(t, uint32(96), NormalizedVariantValue("123", "gr1", 100, VariantNormalizationSeed))
+	assert.Equal(t, uint32(60), NormalizedVariantValue("999", "groupX", 100, VariantNormalizationSeed))
 }
 
 func TestCoalesce(t *testing.T) {
@@ -109,14 +114,14 @@ func BenchmarkNormalizedValue(b *testing.B) {
 	b.Run("value less than 32 bytes", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = normalizedValue(smallId, smallGroup)
+			_ = normalizedRolloutValue(smallId, smallGroup)
 		}
 	})
 
 	b.Run("value greater than 32 bytes", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = normalizedValue(largeId, largeGroup)
+			_ = normalizedRolloutValue(largeId, largeGroup)
 		}
 	})
 }


### PR DESCRIPTION
### What
Uses a new seed for ensuring a fair distribution for variants.

### Background
After a customer reported that variant distribution seemed skewed we performed some testing and found that since we use the same hash string for both gradual rollout and variant allocation we'd reduced the set of groups we could get to whatever percentage our gradual rollout was set.

### Example
Take a gradualRollout of 10%, this will select normalized hashes between 1 and 10, when we then again hash the same string that gave us between 1 and 10, but with modulo 1000 for variants, this will only give us 100 possible groups, instead of the expected 1000.

### Fix
Force the normalization to accept a seed, and make sure to use a new seed when normalizing the variant distribution hash.

### Worth noting
This will require release 4.0.0, since we are changing how hashing works.