### PR TITLE
docs: improve onboarding

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Go vet
         run: go vet ./...
       - name: Run all tests
+        timeout-minutes: 1
         run: go test -race -covermode atomic -coverprofile=profile.cov -v ./...
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ func init() {
 		unleash.WithUrl("http://unleash.herokuapp.com/api/"),
 		unleash.WithCustomHeaders(http.Header{"Authorization": {"<API token>"}}),
 	)
+
+        // The line below will block until the default client is ready or returns immediately. You can wait for readiness in a different way but this is good for new joiners
+        unleash.WaitForReady()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ go get github.com/Unleash/unleash-client-go
 
 The easiest way to get started with Unleash is to initialize it early in your application code:
 
+**Asynchronous initialization example:**
+```go
+import (
+	"github.com/Unleash/unleash-client-go/v4"
+)
+
+func init() {
+	unleash.Initialize(
+		unleash.WithListener(&unleash.DebugListener{}),
+		unleash.WithAppName("my-application"),
+		unleash.WithUrl("http://unleash.herokuapp.com/api/"),
+		unleash.WithCustomHeaders(http.Header{"Authorization": {"<API token>"}}),
+	)
+}
+```
+
+**Synchronous initialization example:**
+
 ```go
 import (
 	"github.com/Unleash/unleash-client-go/v4"
@@ -47,8 +65,8 @@ func init() {
 		unleash.WithCustomHeaders(http.Header{"Authorization": {"<API token>"}}),
 	)
 
-        // The line below will block until the default client is ready or returns immediately. You can wait for readiness in a different way but this is good for new joiners
-        unleash.WaitForReady()
+	// Note this will block until the default client is ready
+	unleash.WaitForReady()
 }
 ```
 


### PR DESCRIPTION
When getting started with go sdk it's easy to miss waiting for initialization. This change will make it easy for newcomers to use the SDK and more advanced users should be able to wait for the readiness in different ways if they don't want to block the main thread

