### PR TITLE
feat: obey http status and backoff on 429, 50x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run spec tests
         run: go test -v ./... -tags='norace'
       - name: Run all tests with race detection
-        timeout-minutes: 3
+        timeout-minutes: 1
         run: go test -race -covermode atomic -coverprofile=profile.cov -v ./... -tags='!norace'
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run spec tests
         run: go test -v ./... -tags='norace'
       - name: Run all tests with race detection
-        timeout-minutes: 1
+        timeout-minutes: 3
         run: go test -race -covermode atomic -coverprofile=profile.cov -v ./... -tags='!norace'
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1

--- a/metrics.go
+++ b/metrics.go
@@ -81,6 +81,7 @@ func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 		closed:          make(chan struct{}),
 		maxSkips:        10,
 		errors:          0,
+		skips:           0,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	m.ctx = ctx

--- a/metrics.go
+++ b/metrics.go
@@ -188,12 +188,12 @@ func (m *metrics) sendMetrics() {
 	defer resp.Body.Close()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
-		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
 			m.configurationError()
-		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode > http.StatusInternalServerError {
+		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
 			m.backoff()
 		}
+		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
 		// The post failed, re-add the metrics we attempted to send so
 		// they are included in the next post.
 		for name, tc := range bucket.Toggles {

--- a/metrics.go
+++ b/metrics.go
@@ -118,7 +118,7 @@ func (m *metrics) sync() {
 	for {
 		select {
 		case <-m.ticker.C:
-			if m.errors == 0 {
+			if m.skips == 0 {
 				m.sendMetrics()
 			} else {
 				m.decrementSkip()

--- a/metrics.go
+++ b/metrics.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"sync"
@@ -66,6 +67,9 @@ type metrics struct {
 	closed   chan struct{}
 	ctx      context.Context
 	cancel   func()
+	maxSkips float64
+	errors   float64
+	skips    float64
 }
 
 func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
@@ -75,6 +79,8 @@ func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 		started:         time.Now(),
 		close:           make(chan struct{}),
 		closed:          make(chan struct{}),
+		maxSkips:        10,
+		errors:          0,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	m.ctx = ctx
@@ -111,7 +117,11 @@ func (m *metrics) sync() {
 	for {
 		select {
 		case <-m.ticker.C:
-			m.sendMetrics()
+			if m.errors == 0 {
+				m.sendMetrics()
+			} else {
+				m.decrementSkip()
+			}
 		case <-m.close:
 			close(m.closed)
 			return
@@ -136,7 +146,24 @@ func (m *metrics) registerInstance() {
 
 	m.registered <- payload
 }
+func (m *metrics) backoff() {
+	m.errors = math.Min(m.maxSkips, m.errors+1)
+	m.skips = m.errors
+}
 
+func (m *metrics) configurationError() {
+	m.errors = m.maxSkips
+	m.skips = m.errors
+}
+
+func (m *metrics) successfulPost() {
+	m.errors = math.Max(0, m.errors-1)
+	m.skips = m.errors
+}
+
+func (m *metrics) decrementSkip() {
+	m.skips = math.Max(0, m.skips-1)
+}
 func (m *metrics) sendMetrics() {
 	m.bucketMu.Lock()
 	bucket := m.resetBucket()
@@ -161,6 +188,11 @@ func (m *metrics) sendMetrics() {
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusMultipleChoices {
 		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound {
+			m.configurationError()
+		} else if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode > http.StatusInternalServerError {
+			m.backoff()
+		}
 		// The post failed, re-add the metrics we attempted to send so
 		// they are included in the next post.
 		for name, tc := range bucket.Toggles {
@@ -174,6 +206,7 @@ func (m *metrics) sendMetrics() {
 		m.bucket.Start = bucket.Start
 		m.bucketMu.Unlock()
 	} else {
+		m.successfulPost()
 		m.sent <- payload
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -339,3 +339,102 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
+
+func TestMetrics_ShouldBackoffOn500(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		Reply(200)
+	gock.New(mockerServer).
+		Post("/client/metrics").
+		Persist().
+		Reply(500)
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData")).Return()
+	mockListener.On("OnCount", "foo", false).Return()
+	mockListener.On("OnCount", "bar", false).Return()
+	mockListener.On("OnCount", "baz", false).Return()
+	mockListener.On("OnWarning", mock.MatchedBy(func(e error) bool {
+		return strings.HasSuffix(e.Error(), "http://foo.com/client/metrics return 500")
+	})).Return()
+	mockListener.On("OnError", mock.Anything).Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithMetricsInterval(50*time.Millisecond),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+	client.IsEnabled("foo")
+	client.IsEnabled("bar")
+	client.IsEnabled("baz")
+
+	time.Sleep(320 * time.Millisecond)
+	assert.Equal(float64(3), client.metrics.errors)
+	err = client.Close()
+	assert.Nil(err, "Client should close without a problem")
+
+}
+
+func TestMetrics_ErrorCountShouldDecreaseIfSuccessful(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		Reply(200)
+	gock.New(mockerServer).
+		Post("/client/metrics").
+		Times(2).
+		Reply(500)
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+	gock.New(mockerServer).
+		Post("/client/metrics").
+		Persist().
+		Reply(200)
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData")).Return()
+	mockListener.On("OnCount", "foo", false).Return()
+	mockListener.On("OnCount", "bar", false).Return()
+	mockListener.On("OnCount", "baz", false).Return()
+	mockListener.On("OnWarning", mock.MatchedBy(func(e error) bool {
+		return strings.HasSuffix(e.Error(), "http://foo.com/client/metrics return 500")
+	})).Return()
+	mockListener.On("OnError", mock.Anything).Return()
+	mockListener.On("OnSent", mock.Anything).Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithMetricsInterval(50*time.Millisecond),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+	client.IsEnabled("foo")
+	client.IsEnabled("bar")
+	client.IsEnabled("baz")
+	time.Sleep(360 * time.Millisecond)
+	client.IsEnabled("foo")
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(float64(0), client.metrics.errors)
+	err = client.Close()
+	assert.Nil(err, "Client should close without a problem")
+}

--- a/repository.go
+++ b/repository.go
@@ -169,12 +169,12 @@ func (r *repository) fetch() error {
 
 func (r *repository) statusIsOK(resp *http.Response) error {
 	s := resp.StatusCode
-	if 200 <= s && s < 300 {
+	if http.StatusOK <= s && s < http.StatusMultipleChoices {
 		return nil
-	} else if s == 401 || s == 403 || s == 404 {
+	} else if s == http.StatusUnauthorized || s == http.StatusForbidden || s == http.StatusNotFound {
 		r.configurationError()
 		return fmt.Errorf("%s %s returned status code %d your SDK is most likely misconfigured, backing off to maximum (%f times our interval)", resp.Request.Method, resp.Request.URL, s, r.maxSkips)
-	} else if s == 429 || s >= 500 {
+	} else if s == http.StatusTooManyRequests || s >= http.StatusInternalServerError {
 		r.backoff()
 		return fmt.Errorf("%s %s returned status code %d, backing off (%f times our interval)", resp.Request.Method, resp.Request.URL, s, r.errors)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -129,6 +129,7 @@ func TestRepository_ParseAPIResponse(t *testing.T) {
 	assert.Equal(0, len(response.Segments))
 }
 
+
 func TestRepository_backs_off_on_http_statuses(t *testing.T) {
 	a := assert.New(t)
 	testCases := []struct {
@@ -157,12 +158,11 @@ func TestRepository_backs_off_on_http_statuses(t *testing.T) {
 		)
 		a.Nil(err)
 		time.Sleep(20 * time.Millisecond)
-		a.Equal(tc.errorCount, client.repository.errors)
 		err = client.Close()
+		a.Equal(tc.errorCount, client.repository.errors)
 		a.Nil(err)
 	}
 }
-
 func TestRepository_back_offs_are_gradually_reduced_on_success(t *testing.T) {
 	a := assert.New(t)
 	defer gock.Off()
@@ -183,7 +183,7 @@ func TestRepository_back_offs_are_gradually_reduced_on_success(t *testing.T) {
 	)
 	a.Nil(err)
 	client.WaitForReady()
-	a.Equal(float64(3), client.repository.errors) // 4 failures, and then one success, should reduce error count to 3
 	err = client.Close()
+	a.Equal(float64(3), client.repository.errors) // 4 failures, and then one success, should reduce error count to 3
 	a.Nil(err)
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -1,3 +1,4 @@
+//go:build norace
 // +build norace
 
 package unleash

--- a/utils.go
+++ b/utils.go
@@ -66,7 +66,7 @@ func every(slice interface{}, condition func(interface{}) bool) bool {
 		return false
 	}
 
-	if (sliceValue.Len() == 0) {
+	if sliceValue.Len() == 0 {
 		return false
 	}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -116,4 +116,3 @@ func TestContains(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION

This follows the same pattern as Java and .NET.  each 429, 50x error will increment error count, and reset skips to error, then for each trigger reduce skips by 1 until you reach 0, then perform the action again. on success reduce error count by 1 and reset skips to error count.

On 401,403,404 will increment skips/errors to max at once and return an error saying you might've configured the client wrong