### PR TITLE
chore: clean tests usage of endpoints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,15 +9,15 @@ jobs:
       matrix:
         version: [1.13, 1.15, 1.16]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout client specifications
         with:
           repository: Unleash/client-specification
           ref: refs/tags/v5.1.0
           path: testdata/client-specification
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         name: Setup go
         with:
           go-version: ${{ matrix.version }}

--- a/client.go
+++ b/client.go
@@ -130,11 +130,11 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 	}()
 
 	if uc.options.url == "" {
-		return nil, fmt.Errorf("Unleash server URL missing")
+		return nil, fmt.Errorf("unleash server URL missing")
 	}
 
 	if strings.HasSuffix(uc.options.url, deprecatedSuffix) {
-		uc.warn(fmt.Errorf("Unleash server URL %s should no longer link directly to /features", uc.options.url))
+		uc.warn(fmt.Errorf("unleash server URL %s should no longer link directly to /features", uc.options.url))
 		uc.options.url = strings.TrimSuffix(uc.options.url, deprecatedSuffix)
 	}
 
@@ -148,7 +148,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 	}
 
 	if uc.options.appName == "" {
-		return nil, fmt.Errorf("Unleash client appName missing")
+		return nil, fmt.Errorf("unleash client appName missing")
 	}
 
 	if uc.options.instanceId == "" {
@@ -358,7 +358,7 @@ func (uc *Client) isParentDependencySatisfied(feature *api.Feature, context cont
 
 		enabledResult := uc.isEnabled(parent.Feature, WithContext(context))
 		// According to the schema, if the enabled property is absent we assume it's true.
-		if parent.Enabled == nil || *parent.Enabled == true {
+		if parent.Enabled == nil || *parent.Enabled {
 			if parent.Variants != nil && len(*parent.Variants) > 0 && enabledResult.Variant != nil {
 				return enabledResult.Enabled && contains(*parent.Variants, enabledResult.Variant.Name)
 			}
@@ -372,11 +372,7 @@ func (uc *Client) isParentDependencySatisfied(feature *api.Feature, context cont
 		return dependenciesSatisfied(parent.(api.Dependency))
 	})
 
-	if !allDependenciesSatisfied {
-		return false
-	}
-
-	return true
+	return allDependenciesSatisfied
 }
 
 // GetVariant queries a variant as the specified feature is enabled.

--- a/client_test.go
+++ b/client_test.go
@@ -34,25 +34,6 @@ func TestClientWithoutListener(t *testing.T) {
 	)
 	assert.Nil(err, "client should not return an error")
 
-	go func() {
-		timeout := time.After(1 * time.Second)
-		for {
-			select {
-			case e := <-client.Errors():
-				t.Errorf("Unexpected error: %v", e)
-				return
-			case w := <-client.Warnings():
-				t.Errorf("Unexpected warning: %v", w)
-				return
-			case <-client.Count():
-			case <-client.Sent():
-			case <-timeout:
-				return
-			}
-		}
-	}()
-	<-client.Registered()
-	<-client.Ready()
 	err = client.Close()
 	assert.Nil(err)
 	assert.True(gock.IsDone(), "there should be no more mocks")

--- a/client_test.go
+++ b/client_test.go
@@ -35,6 +35,7 @@ func TestClientWithoutListener(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 
 	go func() {
+		timeout := time.After(1 * time.Second)
 		for {
 			select {
 			case e := <-client.Errors():
@@ -45,6 +46,8 @@ func TestClientWithoutListener(t *testing.T) {
 				return
 			case <-client.Count():
 			case <-client.Sent():
+			case <-timeout:
+				return
 			}
 		}
 	}()

--- a/client_test.go
+++ b/client_test.go
@@ -53,7 +53,8 @@ func TestClientWithoutListener(t *testing.T) {
 	}()
 	<-client.Registered()
 	<-client.Ready()
-	client.Close()
+	err = client.Close()
+	assert.Nil(err)
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1,7 +1,6 @@
 package unleash
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/Unleash/unleash-client-go/v4/api"
@@ -635,8 +634,6 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	fmt.Printf("%v", client.repository.segments)
-
 	isEnabled := client.IsEnabled(feature, WithContext(context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
 	}))
@@ -752,8 +749,6 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	fmt.Printf("%v", client.repository.segments)
-
 	variant := client.GetVariant(feature, WithVariantContext(context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
 	}))
@@ -868,8 +863,6 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 
 	assert.NoError(err)
 	client.WaitForReady()
-
-	fmt.Printf("%v", client.repository.segments)
 
 	variant := client.GetVariant(feature, WithVariantContext(context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -2,7 +2,7 @@ package unleash_test
 
 import (
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -24,7 +24,7 @@ func Test_bootstrapFromFile(t *testing.T) {
 		Persist().
 		Reply(200)
 		// Read the file into a byte slice
-	byteValue, _ := io.ReadAll(demoReader)
+	byteValue, _ := ioutil.ReadAll(demoReader)
 	// Convert the byte slice to a string
 	jsonStr := string(byteValue)
 

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -1,7 +1,6 @@
 package unleash_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -49,7 +48,6 @@ func Test_bootstrapFromFile(t *testing.T) {
 	}
 
 	enabled := unleash.IsEnabled("DateExample", unleash.WithContext(context.Context{}))
-	fmt.Printf("feature is enabled? %v\n", enabled)
 	a.True(enabled)
 	err = unleash.Close()
 	a.Nil(err)

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -14,6 +14,7 @@ import (
 
 func Test_bootstrapFromFile(t *testing.T) {
 	a := assert.New(t)
+	defer gock.OffAll()
 	demoReader, err := os.Open("demo_app_toggles.json")
 	if err != nil {
 		t.Fail()

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -24,7 +24,11 @@ func Test_bootstrapFromFile(t *testing.T) {
 		Persist().
 		Reply(200)
 		// Read the file into a byte slice
-	byteValue, _ := ioutil.ReadAll(demoReader)
+	featuresReader, err := os.Open("demo_app_toggles.json")
+	if err != nil {
+		t.Fail()
+	}
+	byteValue, _ := ioutil.ReadAll(featuresReader)
 	// Convert the byte slice to a string
 	jsonStr := string(byteValue)
 

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -2,26 +2,42 @@ package unleash_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/Unleash/unleash-client-go/v4"
 	"github.com/Unleash/unleash-client-go/v4/context"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func Test_bootstrapFromFile(t *testing.T) {
+	a := assert.New(t)
 	demoReader, err := os.Open("demo_app_toggles.json")
 	if err != nil {
 		t.Fail()
 	}
+	gock.New("http://foo.com").
+		Post("/client/register").
+		Persist().
+		Reply(200)
+		// Read the file into a byte slice
+	byteValue, _ := io.ReadAll(demoReader)
+	// Convert the byte slice to a string
+	jsonStr := string(byteValue)
+
+	// Use the string as the body of the Gock request
+	gock.New("http://foo.com").
+		Get("/client/features").Persist().Reply(200).BodyString(jsonStr)
 	err = unleash.Initialize(
 		unleash.WithListener(&unleash.DebugListener{}),
 		unleash.WithAppName("my-application"),
 		unleash.WithRefreshInterval(5*time.Second),
-		unleash.WithMetricsInterval(5*time.Second),
+		unleash.WithDisableMetrics(true),
 		unleash.WithStorage(&unleash.BootstrapStorage{Reader: demoReader}),
-		unleash.WithUrl("https://localhost:4242"),
+		unleash.WithUrl("http://foo.com"),
 	)
 
 	if err != nil {
@@ -30,7 +46,7 @@ func Test_bootstrapFromFile(t *testing.T) {
 
 	enabled := unleash.IsEnabled("DateExample", unleash.WithContext(context.Context{}))
 	fmt.Printf("feature is enabled? %v\n", enabled)
-	if enabled == false {
-		t.Fatalf("Expected feature to be enabled")
-	}
+	a.True(enabled)
+	err = unleash.Close()
+	a.Nil(err)
 }

--- a/internal/strategies/flexible_rollout_test.go
+++ b/internal/strategies/flexible_rollout_test.go
@@ -1,3 +1,4 @@
+//go:build norace
 // +build norace
 
 package strategies

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -117,7 +117,7 @@ func TestMetrics_DoPost(t *testing.T) {
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
-		WithListener(mockListener),
+		WithListener(&DebugListener{}),
 	)
 
 	assert.Nil(err, "client should not return an error")

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -2,15 +2,32 @@ package unleash_test
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/Unleash/unleash-client-go/v4"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
 )
 
 func Test_withVariants(t *testing.T) {
+	a := assert.New(t)
 	demoReader, err := os.Open("demo_app_toggles.json")
+	defer gock.OffAll()
+
+	gock.New("http://foo.com").
+		Post("/client/register").
+		Reply(200)
+		// Read the file into a byte slice
+	byteValue, _ := io.ReadAll(demoReader)
+	// Convert the byte slice to a string
+	jsonStr := string(byteValue)
+
+	// Use the string as the body of the Gock request
+	gock.New("http://foo.com").
+		Get("/client/features").Reply(200).BodyString(jsonStr)
 	if err != nil {
 		t.Fail()
 	}
@@ -18,9 +35,9 @@ func Test_withVariants(t *testing.T) {
 		unleash.WithListener(&unleash.DebugListener{}),
 		unleash.WithAppName("my-application"),
 		unleash.WithRefreshInterval(5*time.Second),
-		unleash.WithMetricsInterval(5*time.Second),
+		unleash.WithDisableMetrics(true),
 		unleash.WithStorage(&unleash.BootstrapStorage{Reader: demoReader}),
-		unleash.WithUrl("https://localhost:4242"),
+		unleash.WithUrl("http://foo.com"),
 	)
 
 	if err != nil {
@@ -38,20 +55,36 @@ func Test_withVariants(t *testing.T) {
 	if feature.Payload.Value != "35" && feature.Payload.Value != "55" {
 		t.Fatalf("Expected one of the variant payloads")
 	}
+	err = unleash.Close()
+	a.Nil(err)
 }
 
 func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
+	a := assert.New(t)
 	demoReader, err := os.Open("demo_app_toggles.json")
 	if err != nil {
 		t.Fail()
 	}
+	defer gock.OffAll()
+
+	gock.New("http://foo.com").
+		Post("/client/register").
+		Reply(200)
+
+	byteValue, _ := io.ReadAll(demoReader)
+	// Convert the byte slice to a string
+	jsonStr := string(byteValue)
+
+	// Use the string as the body of the Gock request
+	gock.New("http://foo.com").
+		Get("/client/features").Reply(200).BodyString(jsonStr)
 	err = unleash.Initialize(
 		unleash.WithListener(&unleash.DebugListener{}),
 		unleash.WithAppName("my-application"),
-		unleash.WithRefreshInterval(5*time.Second),
-		unleash.WithMetricsInterval(5*time.Second),
+		unleash.WithRefreshInterval(20*time.Second),
+		unleash.WithDisableMetrics(true),
 		unleash.WithStorage(&unleash.BootstrapStorage{Reader: demoReader}),
-		unleash.WithUrl("https://localhost:4242"),
+		unleash.WithUrl("http://foo.com"),
 	)
 
 	if err != nil {
@@ -63,6 +96,8 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 	if feature.Enabled == true {
 		t.Fatalf("Expected feature to be disabled because Environment does not exist as strategy")
 	}
+	err = unleash.Close()
+	a.Nil(err)
 }
 
 func Test_IsEnabledWithUninitializedClient(t *testing.T) {
@@ -70,4 +105,5 @@ func Test_IsEnabledWithUninitializedClient(t *testing.T) {
 	if !result {
 		t.Fatalf("Expected true")
 	}
+
 }

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -2,7 +2,7 @@ package unleash_test
 
 import (
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -21,7 +21,7 @@ func Test_withVariants(t *testing.T) {
 		Post("/client/register").
 		Reply(200)
 		// Read the file into a byte slice
-	byteValue, _ := io.ReadAll(demoReader)
+	byteValue, _ := ioutil.ReadAll(demoReader)
 	// Convert the byte slice to a string
 	jsonStr := string(byteValue)
 
@@ -71,7 +71,7 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 		Post("/client/register").
 		Reply(200)
 
-	byteValue, _ := io.ReadAll(demoReader)
+	byteValue, _ := ioutil.ReadAll(demoReader)
 	// Convert the byte slice to a string
 	jsonStr := string(byteValue)
 

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -1,7 +1,6 @@
 package unleash_test
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -50,7 +49,6 @@ func Test_withVariants(t *testing.T) {
 	}
 
 	feature := unleash.GetVariant("Demo")
-	fmt.Printf("feature is %v\n", feature)
 	if feature.Enabled == false {
 		t.Fatalf("Expected feature to be enabled")
 	}
@@ -107,7 +105,6 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 	}
 
 	feature := unleash.GetVariant("AuditLog")
-	fmt.Printf("feature is %v\n", feature)
 	if feature.Enabled == true {
 		t.Fatalf("Expected feature to be disabled because Environment does not exist as strategy")
 	}

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -15,15 +15,20 @@ import (
 func Test_withVariants(t *testing.T) {
 	a := assert.New(t)
 	demoReader, err := os.Open("demo_app_toggles.json")
+	if err != nil {
+		t.Fail()
+	}
 	defer gock.OffAll()
+	defer demoReader.Close()
 
 	gock.New("http://foo.com").
 		Post("/client/register").
 		Reply(200)
-		// Read the file into a byte slice
-	byteValue, _ := ioutil.ReadAll(demoReader)
-	// Convert the byte slice to a string
-	jsonStr := string(byteValue)
+
+	jsonStr, err := read_demo_app_toggles()
+	if err != nil {
+		t.Fail()
+	}
 
 	// Use the string as the body of the Gock request
 	gock.New("http://foo.com").
@@ -59,6 +64,16 @@ func Test_withVariants(t *testing.T) {
 	a.Nil(err)
 }
 
+func read_demo_app_toggles() (string, error) {
+	demoReader, err := os.Open("demo_app_toggles.json")
+	if err != nil {
+		return "", err
+	}
+	defer demoReader.Close()
+	byteValue, _ := ioutil.ReadAll(demoReader)
+	return string(byteValue), nil
+}
+
 func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 	a := assert.New(t)
 	demoReader, err := os.Open("demo_app_toggles.json")
@@ -70,10 +85,10 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 	gock.New("http://foo.com").
 		Post("/client/register").
 		Reply(200)
-
-	byteValue, _ := ioutil.ReadAll(demoReader)
-	// Convert the byte slice to a string
-	jsonStr := string(byteValue)
+	jsonStr, err := read_demo_app_toggles()
+	if err != nil {
+		t.Fail()
+	}
 
 	// Use the string as the body of the Gock request
 	gock.New("http://foo.com").


### PR DESCRIPTION
Previously, once we hit the feature refresh interval, we saw failed requests against https://localhost:4242, this update replaces all usages in these tests with the gocked url instead of a fake localhost address