### PR TITLE
feat(api): add type to Feature

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -26,6 +26,9 @@ type Feature struct {
 	// Name is the name of the feature toggle.
 	Name string `json:"name"`
 
+	// Type is the type of the feature toggle.
+	Type string `json:"type"`
+
 	// Description is a description of the feature toggle.
 	Description string `json:"description"`
 


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

Adds the `Type` field to `api.Feature` which is already returned by the API but was not captured in the Go struct.

<!-- Does it close an issue? Multiple? -->
Closes #162

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->

This will be slightly difficult for us to get to in normal usage since `IsEnabled` and `GetVariant` do not expose the underlying `api.Feature`. We plan to add our own `map[string]*api.Feature` to our internal client so we can resolve the underlying feature after we call `GetVariant`.