### PR TITLE
[wip] fix: variant fallback usage

### DIFF
--- a/client.go
+++ b/client.go
@@ -417,8 +417,13 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 
 	if !strategyResult.Enabled {
 		if opts.variantFallbackFunc != nil {
-			return opts.variantFallbackFunc(feature, ctx)
+			variant := opts.variantFallbackFunc(feature, ctx)
+			if variant != nil {
+				variant.FeatureEnabled = false
+			}
+			return variant
 		} else if opts.variantFallback != nil {
+			opts.variantFallback.FeatureEnabled = false
 			return opts.variantFallback
 		}
 		return defaultVariant
@@ -431,18 +436,20 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 		f = uc.repository.getToggle(feature)
 	}
 
-	if f == nil {
+	if f == nil || !f.Enabled {
 		if opts.variantFallbackFunc != nil {
-			return opts.variantFallbackFunc(feature, ctx)
+			variant := opts.variantFallbackFunc(feature, ctx)
+			if variant != nil {
+				variant.FeatureEnabled = false
+			}
+			return variant
 		} else if opts.variantFallback != nil {
+			opts.variantFallback.FeatureEnabled = false
 			return opts.variantFallback
 		}
 		return defaultVariant
 	}
 
-	if !f.Enabled {
-		return defaultVariant
-	}
 
 	if strategyResult.Variant != nil {
 		return strategyResult.Variant

--- a/client.go
+++ b/client.go
@@ -449,6 +449,16 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 	}
 
 	if len(f.Variants) == 0 {
+		if opts.variantFallbackFunc != nil {
+			variant := opts.variantFallbackFunc(feature, ctx)
+			if variant != nil {
+				variant.FeatureEnabled = true
+			}
+			return variant
+		} else if opts.variantFallback != nil {
+			opts.variantFallback.FeatureEnabled = true
+			return opts.variantFallback
+		}
 		return disabledVariantFeatureEnabled
 	}
 

--- a/client.go
+++ b/client.go
@@ -416,6 +416,11 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 	}
 
 	if !strategyResult.Enabled {
+		if opts.variantFallbackFunc != nil {
+			return opts.variantFallbackFunc(feature, ctx)
+		} else if opts.variantFallback != nil {
+			return opts.variantFallback
+		}
 		return defaultVariant
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -1198,6 +1198,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
+                FeatureEnabled: true,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
@@ -1272,6 +1273,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
+                FeatureEnabled: false,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
@@ -1292,9 +1294,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
-
-// test cases (each with fallback and fallbackfunc):
-// 4. test strategy variants too
 
 func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 	assert := assert.New(t)
@@ -1337,6 +1336,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
+                FeatureEnabled: true,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))

--- a/client_test.go
+++ b/client_test.go
@@ -1151,7 +1151,6 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 // 3. feature is enabled but no variants -> FeatureEnabled : true
 // 4. test strategy variants too
 
-
 func TestGetVariantWithFallbackVariant(t *testing.T) {
 	assert := assert.New(t)
 	defer gock.OffAll()
@@ -1215,20 +1214,13 @@ func TestGetVariantWithFallbackVariant(t *testing.T) {
 
 	assert.Equal(fallbackVariant, *variant)
 
-	variantFromResolver := client.GetVariant(feature, WithVariantFallback(&fallbackVariant), WithVariantResolver(func(featureName string) *api.Feature {
-		if featureName == features[0].Name {
-			return &features[0]
-		} else {
-			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
-			return nil
-		}
-	}))
+	fallbackFunc := func(feature string, ctx *context.Context) *api.Variant {
+		return &fallbackVariant
+	}
 
-	assert.False(variantFromResolver.Enabled)
+	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
 
-	assert.False(variantFromResolver.FeatureEnabled)
-
-	assert.Equal(fallbackVariant, *variantFromResolver)
+	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1151,7 +1151,7 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 // 3. feature is enabled but no variants -> FeatureEnabled : true
 // 4. test strategy variants too
 
-func TestGetVariantWithFallbackVariant(t *testing.T) {
+func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 	assert := assert.New(t)
 	defer gock.OffAll()
 


### PR DESCRIPTION
This PR fixes a bug in how we use fallback variants in this SDK.

The fallback should be used when there is no flag, when the flag doesn't have any variants, and if the flag has variants, but is disabled. However, prior to this, it was only used if the flag didn't exist.

It addresses the issues in and closes #160.

## Discussion points

### Overriding `FeatureEnabled`

Comparing this to the Node SDK, I noticed one thing that we don't seem to do: setting the `FeatureEnabled` property based on the flag's enabled state. 

Because the fallback you pass in also has `FeatureEnabled` as a property, you can in theory override this. However, that means you can get into situations where the flag is actually enabled, but the variant says `FeatureEnabled` is `false` because that's what the fallback says. That seems incorrect to me, so I've added in some handling for that, but I'd like to get a second opinion on it.

### Code quality

This may be my first time writing Go, so it's very possible that I've missed some idioms or similar. Please feel free to correct as many things as you want.