### PR TITLE
fix: variant fallback usage

### DIFF
--- a/client.go
+++ b/client.go
@@ -418,13 +418,8 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 
 	getFallbackVariant := func(featureEnabled bool) *api.Variant {
 		if opts.variantFallbackFunc != nil {
-			variant := opts.variantFallbackFunc(feature, ctx)
-			if variant != nil {
-				variant.FeatureEnabled = featureEnabled
-			}
-			return variant
+			return opts.variantFallbackFunc(feature, ctx)
 		} else if opts.variantFallback != nil {
-			opts.variantFallback.FeatureEnabled = featureEnabled
 			return opts.variantFallback
 		}
 

--- a/client.go
+++ b/client.go
@@ -416,7 +416,7 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 		strategyResult, f = uc.isEnabled(feature, WithContext(*ctx))
 	}
 
-	getFallbackWithFeatureEnabled := func(featureEnabled bool) *api.Variant {
+	getFallbackVariant := func(featureEnabled bool) *api.Variant {
 		if opts.variantFallbackFunc != nil {
 			variant := opts.variantFallbackFunc(feature, ctx)
 			if variant != nil {
@@ -435,11 +435,11 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 	}
 
 	if !strategyResult.Enabled {
-		return getFallbackWithFeatureEnabled(false)
+		return getFallbackVariant(false)
 	}
 
 	if f == nil || !f.Enabled {
-		return getFallbackWithFeatureEnabled(false)
+		return getFallbackVariant(false)
 	}
 
 	if strategyResult.Variant != nil {
@@ -447,7 +447,7 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 	}
 
 	if len(f.Variants) == 0 {
-		return getFallbackWithFeatureEnabled(true)
+		return getFallbackVariant(true)
 	}
 
 	return api.VariantCollection{

--- a/client_test.go
+++ b/client_test.go
@@ -1180,17 +1180,11 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 			Segments: []api.Segment{},
 		})
 
-	mockListener := &MockedListener{}
-	mockListener.On("OnReady").Return()
-	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, false).Return()
-	mockListener.On("OnError").Return()
-
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
-		WithListener(mockListener),
+		WithListener(&NoopListener{}),
 	)
 
 	assert.NoError(err)
@@ -1255,17 +1249,11 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 			Segments: []api.Segment{},
 		})
 
-	mockListener := &MockedListener{}
-	mockListener.On("OnReady").Return()
-	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
-	mockListener.On("OnError").Return()
-
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
-		WithListener(mockListener),
+		WithListener(&NoopListener{}),
 	)
 
 	assert.NoError(err)
@@ -1318,17 +1306,11 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 			Segments: []api.Segment{},
 		})
 
-	mockListener := &MockedListener{}
-	mockListener.On("OnReady").Return()
-	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, false).Return()
-	mockListener.On("OnError").Return()
-
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithInstanceId(mockInstanceId),
-		WithListener(mockListener),
+		WithListener(&NoopListener{}),
 	)
 
 	assert.NoError(err)

--- a/client_test.go
+++ b/client_test.go
@@ -1292,9 +1292,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 		Reply(200)
 
 	feature := "feature-no-variants"
-	features := []api.Feature{
-		{},
-	}
+	features := []api.Feature{}
 
 	gock.New(mockerServer).
 		Get("/client/features").

--- a/client_test.go
+++ b/client_test.go
@@ -1192,7 +1192,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
-                FeatureEnabled: true,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
@@ -1261,14 +1260,13 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
-                FeatureEnabled: false,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
 
 	assert.False(variant.Enabled)
 
-	assert.True(variant.FeatureEnabled)
+	assert.False(variant.FeatureEnabled)
 
 	assert.Equal(fallbackVariant, *variant)
 
@@ -1318,7 +1316,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 
 	fallbackVariant := api.Variant{
 		Name: "fallback-variant",
-                FeatureEnabled: true,
 	}
 
 	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))

--- a/client_test.go
+++ b/client_test.go
@@ -1144,3 +1144,216 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
+
+func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
+		Reply(200)
+
+	feature := "feature-disabled"
+	features := []api.Feature{
+		{
+			Name:        feature,
+			Description: "feature-desc",
+			Enabled:     false,
+			CreatedAt:   time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC),
+			Strategy:    "default-strategy",
+			Strategies: []api.Strategy{
+				{
+					Id:   1,
+					Name: "default",
+				},
+			},
+		},
+	}
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{
+			Features: features,
+			Segments: []api.Segment{},
+		})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+	mockListener.On("OnCount", feature, false).Return()
+	mockListener.On("OnError").Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+
+	assert.NoError(err)
+	client.WaitForReady()
+
+	fallbackVariant := api.Variant{
+		Name: "fallback-variant",
+                FeatureEnabled: true,
+	}
+
+	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+
+	assert.False(variant.Enabled)
+
+	assert.False(variant.FeatureEnabled)
+
+	assert.Equal(fallbackVariant, *variant)
+
+	fallbackFunc := func(feature string, ctx *context.Context) *api.Variant {
+		return &fallbackVariant
+	}
+
+	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+
+	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
+
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}
+
+func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
+		Reply(200)
+
+	feature := "feature-no-variants"
+	features := []api.Feature{
+		{
+			Name:        feature,
+			Description: "feature-desc",
+			Enabled:     true,
+			CreatedAt:   time.Date(1974, time.May, 19, 1, 2, 3, 4, time.UTC),
+			Strategy:    "default-strategy",
+			Strategies: []api.Strategy{
+				{
+					Id:   1,
+					Name: "default",
+				},
+			},
+		},
+	}
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{
+			Features: features,
+			Segments: []api.Segment{},
+		})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnError").Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+
+	assert.NoError(err)
+	client.WaitForReady()
+
+	fallbackVariant := api.Variant{
+		Name: "fallback-variant",
+                FeatureEnabled: false,
+	}
+
+	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+
+	assert.False(variant.Enabled)
+
+	assert.True(variant.FeatureEnabled)
+
+	assert.Equal(fallbackVariant, *variant)
+
+	fallbackFunc := func(feature string, ctx *context.Context) *api.Variant {
+		return &fallbackVariant
+	}
+
+	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+
+	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
+
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}
+
+func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
+		Reply(200)
+
+	feature := "feature-no-variants"
+	features := []api.Feature{
+		{},
+	}
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{
+			Features: features,
+			Segments: []api.Segment{},
+		})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+	mockListener.On("OnCount", feature, false).Return()
+	mockListener.On("OnError").Return()
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(mockListener),
+	)
+
+	assert.NoError(err)
+	client.WaitForReady()
+
+	fallbackVariant := api.Variant{
+		Name: "fallback-variant",
+                FeatureEnabled: true,
+	}
+
+	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+
+	assert.False(variant.Enabled)
+
+	assert.False(variant.FeatureEnabled)
+
+	assert.Equal(fallbackVariant, *variant)
+
+	fallbackFunc := func(feature string, ctx *context.Context) *api.Variant {
+		return &fallbackVariant
+	}
+
+	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+
+	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
+
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}

--- a/config.go
+++ b/config.go
@@ -214,16 +214,20 @@ type variantOption struct {
 // VariantOption provides options for querying if a variant is found or not.
 type VariantOption func(*variantOption)
 
-// WithVariantFallback specifies what the value should be if the variant is not found on the
-// unleash service.
+// WithVariantFallback specifies what the value should be if the
+// variant is not found on the unleash service. This could be because
+// the feature doesn't exist, because it is disabled, or because it
+// has no variants.
 func WithVariantFallback(variantFallback *api.Variant) VariantOption {
 	return func(opts *variantOption) {
 		opts.variantFallback = variantFallback
 	}
 }
 
-// WithVariantFallbackFunc specifies a fallback function to evaluate a variant
-// is not found on the service.
+// WithVariantFallbackFunc specifies a fallback function to evaluate
+// to a variant when a variant is not found for a feature. This could
+// be because the feature doesn't exist, because it is disabled, or
+// because it has no variants.
 func WithVariantFallbackFunc(variantFallbackFunc VariantFallbackFunc) VariantOption {
 	return func(opts *variantOption) {
 		opts.variantFallbackFunc = variantFallbackFunc

--- a/config.go
+++ b/config.go
@@ -218,6 +218,11 @@ type VariantOption func(*variantOption)
 // variant is not found on the unleash service. This could be because
 // the feature doesn't exist, because it is disabled, or because it
 // has no variants.
+//
+// If you specify a fallback variant, note that its `FeatureEnabled`
+// field will be set to whatever you pass in or `false` by default. In
+// other words, it will not reflect the feature's actual enabled
+// state.
 func WithVariantFallback(variantFallback *api.Variant) VariantOption {
 	return func(opts *variantOption) {
 		opts.variantFallback = variantFallback
@@ -228,6 +233,11 @@ func WithVariantFallback(variantFallback *api.Variant) VariantOption {
 // to a variant when a variant is not found for a feature. This could
 // be because the feature doesn't exist, because it is disabled, or
 // because it has no variants.
+//
+// If you specify a fallback variant, note that its `FeatureEnabled`
+// field will be set to whatever you pass in or `false` by default. In
+// other words, it will not reflect the feature's actual enabled
+// state.
 func WithVariantFallbackFunc(variantFallbackFunc VariantFallbackFunc) VariantOption {
 	return func(opts *variantOption) {
 		opts.variantFallbackFunc = variantFallbackFunc


### PR DESCRIPTION
This PR fixes a bug in how we use fallback variants in this SDK.

The fallback should be used when there is no flag, when the flag doesn't have any variants, and if the flag has variants, but is disabled. However, prior to this, it was only used if the flag didn't exist.

It addresses the issues in and closes #160.

## Discussion points

### Overriding `FeatureEnabled`

Comparing this to the Node SDK, I noticed one thing that we don't seem to do: setting the `FeatureEnabled` property based on the flag's enabled state.

Because the fallback you pass in also has `FeatureEnabled` as a property, you can in theory override this. However, that means you can get into situations where the flag is actually enabled, but the variant says `FeatureEnabled` is `false` because that's what the fallback says. That seems incorrect to me, so I've added in some handling for that, but I'd like to get a second opinion on it.

### Code quality

This may be my first time writing Go, so it's very possible that I've missed some idioms or similar. Please feel free to correct as many things as you want.

This includes the very verbose test setup which accounts for ~85% of this PR. 