### PR TITLE
task: Bumped clientVersion

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ import (
 const (
 	deprecatedSuffix = "/features"
 	clientName       = "unleash-client-go"
-	clientVersion    = "4.0.0"
+	clientVersion    = "4.1.0"
 )
 
 var defaultStrategies = []strategy.Strategy{


### PR DESCRIPTION
As the title says, bumps clientVersion so we can tag 4.1.0