### PR TITLE
feat: automatically generated instanceId

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ go get github.com/Unleash/unleash-client-go
 The easiest way to get started with Unleash is to initialize it early in your application code:
 
 **Asynchronous initialization example:**
+
 ```go
 import (
 	"github.com/Unleash/unleash-client-go/v4"
@@ -69,6 +70,10 @@ func init() {
 	unleash.WaitForReady()
 }
 ```
+
+#### instanceId
+
+Starting from version 5.0.0, `instanceId` is automatically generated and can no longer be set manually.
 
 #### Preloading feature toggles
 
@@ -272,8 +277,6 @@ you can add the following to your apps `go.mod`:
 ```mod
     replace github.com/Unleash/unleash-client-go/v4 => ../unleash-client-go/
 ```
-
-
 
 ## Steps to release
 

--- a/client.go
+++ b/client.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/Unleash/unleash-client-go/v4/api"
 	"github.com/Unleash/unleash-client-go/v4/context"
 	"github.com/Unleash/unleash-client-go/v4/internal/constraints"
@@ -159,9 +161,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		return nil, fmt.Errorf("unleash client appName missing")
 	}
 
-	if uc.options.instanceId == "" {
-		uc.options.instanceId = generateInstanceId()
-	}
+	uc.options.instanceId = uuid.New().String()
 
 	uc.repository = newRepository(
 		repositoryOptions{

--- a/client_test.go
+++ b/client_test.go
@@ -30,7 +30,6 @@ func TestClientWithoutListener(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 	)
 	assert.Nil(err, "client should not return an error")
 
@@ -46,7 +45,6 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	gock.New(mockerServer).
@@ -65,7 +63,6 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -90,7 +87,6 @@ func TestClient_WithResolver(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	gock.New(mockerServer).
@@ -109,7 +105,6 @@ func TestClient_WithResolver(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -198,7 +193,6 @@ func TestClient_ListFeatures(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -232,7 +226,6 @@ func TestClientWithProjectName(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithProjectName(projectName),
 		WithListener(mockListener),
 	)
@@ -265,7 +258,6 @@ func TestClientWithoutProjectName(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -342,7 +334,6 @@ func TestClientWithVariantContext(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -381,7 +372,6 @@ func TestClient_WithSegment(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-segment"
@@ -430,7 +420,6 @@ func TestClient_WithSegment(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -466,7 +455,6 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-segment-non-existing"
@@ -508,7 +496,6 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -545,7 +532,6 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-segment-multiple"
@@ -612,7 +598,6 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -648,7 +633,6 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-segment-multiple"
@@ -727,7 +711,6 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -767,7 +750,6 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-segment-multiple"
@@ -846,7 +828,6 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -949,7 +930,6 @@ func TestClient_ShouldFavorStrategyVariantOverFeatureVariant(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -1049,7 +1029,6 @@ func TestClient_ShouldReturnOldVariantForNonMatchingStrategyVariant(t *testing.T
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -1075,7 +1054,6 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-no-variants"
@@ -1112,7 +1090,6 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -1152,7 +1129,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-disabled"
@@ -1183,7 +1159,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(&NoopListener{}),
 	)
 
@@ -1220,7 +1195,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-no-variants"
@@ -1251,7 +1225,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(&NoopListener{}),
 	)
 
@@ -1292,7 +1265,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	feature := "feature-no-variants"
@@ -1309,7 +1281,6 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(&NoopListener{}),
 	)
 
@@ -1346,7 +1317,6 @@ func TestGetVariant_FallbackVariantFeatureEnabledSettingIsLeftUnchanged(t *testi
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	enabledFeatureNoVariants := "enabled-feature"
@@ -1391,7 +1361,6 @@ func TestGetVariant_FallbackVariantFeatureEnabledSettingIsLeftUnchanged(t *testi
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(&NoopListener{}),
 	)
 

--- a/config.go
+++ b/config.go
@@ -54,14 +54,6 @@ func WithEnvironment(env string) ConfigOption {
 	}
 }
 
-// WithInstanceId specifies the instance identifier of the current instance. If not provided,
-// one will be generated based on various parameters such as current user and hostname.
-func WithInstanceId(instanceId string) ConfigOption {
-	return func(o *configOption) {
-		o.instanceId = instanceId
-	}
-}
-
 // WithUrl specifies the url of the unleash server the user is connecting to.
 func WithUrl(url string) ConfigOption {
 	return func(o *configOption) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Unleash/unleash-client-go/v4
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -26,7 +26,6 @@ func TestMetrics_RegisterInstance(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	gock.New(mockerServer).
@@ -41,7 +40,6 @@ func TestMetrics_RegisterInstance(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -60,7 +58,6 @@ func TestMetrics_VariantsCountToggles(t *testing.T) {
 	gock.New(mockerServer).
 		Post("/client/register").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	gock.New(mockerServer).
@@ -76,7 +73,6 @@ func TestMetrics_VariantsCountToggles(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 
@@ -106,7 +102,6 @@ func TestMetrics_DoPost(t *testing.T) {
 	gock.New(mockerServer).
 		Post("").
 		MatchHeader("UNLEASH-APPNAME", mockAppName).
-		MatchHeader("UNLEASH-INSTANCEID", mockInstanceId).
 		Reply(200)
 
 	mockListener := &MockedListener{}
@@ -116,7 +111,6 @@ func TestMetrics_DoPost(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(&DebugListener{}),
 	)
 
@@ -150,7 +144,6 @@ func TestMetrics_DisabledMetrics(t *testing.T) {
 		WithDisableMetrics(true),
 		WithMetricsInterval(100*time.Millisecond),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 	assert.Nil(err, "client should not return an error")
@@ -221,7 +214,6 @@ func TestMetrics_SendMetricsFail(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(srv.URL),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 		WithMetricsInterval(time.Millisecond),
 	)
@@ -325,7 +317,6 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 	assert.Nil(err, "client should not return an error")
@@ -370,7 +361,6 @@ func TestMetrics_ShouldBackoffOn500(t *testing.T) {
 		WithUrl(mockerServer),
 		WithMetricsInterval(50*time.Millisecond),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
 	assert.Nil(err, "client should not return an error")
@@ -411,7 +401,6 @@ func TestMetrics_ErrorCountShouldDecreaseIfSuccessful(t *testing.T) {
 		WithUrl(mockerServer),
 		WithMetricsInterval(50*time.Millisecond),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 	)
 	assert.Nil(err, "client should not return an error")
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -3,13 +3,14 @@ package unleash
 import (
 	"bytes"
 	"encoding/json"
-	"gopkg.in/h2non/gock.v1"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"gopkg.in/h2non/gock.v1"
 
 	"github.com/Unleash/unleash-client-go/v4/api"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +60,6 @@ func TestRepository_GetFeaturesFail(t *testing.T) {
 	client, err := NewClient(
 		WithUrl(srv.URL),
 		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 		WithRefreshInterval(time.Millisecond),
 	)
@@ -153,7 +153,6 @@ func TestRepository_backs_off_on_http_statuses(t *testing.T) {
 			WithUrl(mockerServer),
 			WithAppName(mockAppName),
 			WithDisableMetrics(true),
-			WithInstanceId(mockInstanceId),
 			WithRefreshInterval(time.Millisecond * 15),
 		)
 		a.Nil(err)
@@ -178,7 +177,6 @@ func TestRepository_back_offs_are_gradually_reduced_on_success(t *testing.T) {
 		WithUrl(mockerServer),
 		WithAppName(mockAppName),
 		WithDisableMetrics(true),
-		WithInstanceId(mockInstanceId),
 		WithRefreshInterval(time.Millisecond * 10),
 	)
 	a.Nil(err)

--- a/unleash_mock.go
+++ b/unleash_mock.go
@@ -10,7 +10,6 @@ import (
 const (
 	mockerServer   = "http://foo.com"
 	mockAppName    = "unleash-client-go-tests"
-	mockInstanceId = "1234"
 )
 
 type MockedListener struct {

--- a/utils.go
+++ b/utils.go
@@ -2,32 +2,13 @@ package unleash
 
 import (
 	"fmt"
-	"math/rand"
 	"os"
-	"os/user"
 	"reflect"
 	"sync"
-	"time"
 )
 
 func getTmpDirPath() string {
 	return os.TempDir()
-}
-
-func generateInstanceId() string {
-	prefix := ""
-
-	if user, err := user.Current(); err == nil && user.Username != "" {
-		prefix = user.Username
-	} else {
-		rand.Seed(time.Now().Unix())
-		prefix = fmt.Sprintf("generated-%d-%d", rand.Intn(1000000), os.Getpid())
-	}
-
-	if hostname, err := os.Hostname(); err == nil && hostname != "" {
-		return fmt.Sprintf("%s-%s", prefix, hostname)
-	}
-	return prefix
 }
 
 func getFetchURLPath(projectName string) string {


### PR DESCRIPTION
https://linear.app/unleash/issue/2-2395/make-instance-id-autogenned-go

This makes `instanceId` an automatically generated property, instead of being set by the user.

Similar to: 
 - https://github.com/Unleash/unleash-client-ruby/pull/179
 - https://github.com/Unleash/unleash-client-node/pull/640
 - https://github.com/Unleash/unleash-client-dotnet/pull/226