### PR TITLE
Feat: support environment and appName variant overrides

### DIFF
--- a/api/variant.go
+++ b/api/variant.go
@@ -61,6 +61,10 @@ func (o Override) getIdentifier(ctx *context.Context) string {
 		value = ctx.SessionId
 	case "remoteAddress":
 		value = ctx.RemoteAddress
+	case "environment":
+		value = ctx.Environment
+	case "appName":
+		value = ctx.AppName
 	default:
 		if len(ctx.Properties) > 0 {
 			for k, v := range ctx.Properties {

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -23,7 +23,7 @@ func (suite *VariantTestSuite) SetupTest() {
 					Value: "Test 1",
 				},
 			},
-			Weight: 33,
+			Weight: 25,
 			Overrides: []Override{
 				Override{
 					ContextName: "userId",
@@ -47,7 +47,7 @@ func (suite *VariantTestSuite) SetupTest() {
 					Value: "Test 2",
 				},
 			},
-			Weight: 33,
+			Weight: 25,
 			Overrides: []Override{
 				Override{
 					ContextName: "remoteAddress",
@@ -65,12 +65,36 @@ func (suite *VariantTestSuite) SetupTest() {
 					Value: "Test 3",
 				},
 			},
-			Weight: 34,
+			Weight: 25,
 			Overrides: []Override{
 				Override{
 					ContextName: "env",
 					Values: []string{
 						"dev",
+					},
+				},
+			},
+		},
+		VariantInternal{
+			Variant: Variant{
+				Name: "VarG",
+				Payload: Payload{
+					Type:  "string",
+					Value: "Test 4",
+				},
+			},
+			Weight: 25,
+			Overrides: []Override{
+				Override{
+					ContextName: "environment",
+					Values: []string{
+						"development",
+					},
+				},
+				Override{
+					ContextName: "appName",
+					Values: []string{
+						"test",
 					},
 				},
 			},
@@ -262,4 +286,48 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarF() {
 func TestVariantSuite(t *testing.T) {
 	ts := VariantTestSuite{}
 	suite.Run(t, &ts)
+}
+
+func (suite *VariantTestSuite) TestGetVariant_OverrideOnAppName() {
+	mockFeature := Feature{
+		Name:     "test.variants",
+		Enabled:  true,
+		Variants: suite.VariantWithOverride,
+	}
+	mockContext := &context.Context{
+		AppName: "test",
+	}
+	expectedPayload := Payload{
+		Type:  "string",
+		Value: "Test 4",
+	}
+	variantSetup := VariantCollection{
+		GroupId:  mockFeature.Name,
+		Variants: mockFeature.Variants,
+	}.GetVariant(mockContext)
+	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
+	suite.Equal(true, variantSetup.Enabled, "Should be equal")
+	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
+}
+
+func (suite *VariantTestSuite) TestGetVariant_OverrideOnEnvironment() {
+	mockFeature := Feature{
+		Name:     "test.variants",
+		Enabled:  true,
+		Variants: suite.VariantWithOverride,
+	}
+	mockContext := &context.Context{
+		Environment: "development",
+	}
+	expectedPayload := Payload{
+		Type:  "string",
+		Value: "Test 4",
+	}
+	variantSetup := VariantCollection{
+		GroupId:  mockFeature.Name,
+		Variants: mockFeature.Variants,
+	}.GetVariant(mockContext)
+	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
+	suite.Equal(true, variantSetup.Enabled, "Should be equal")
+	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
 }


### PR DESCRIPTION
## About the changes
At the moment, the SDK doesn't support setting a variant override for appName / environment despite this being supported by Unleash. This PR adds `environment` and `appName` to `Override.getIdentifier()` to support setting them as variant overrides.

Closes #178