### PR TITLE
Expose ImpressionData property from api.Feature type

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -52,6 +52,9 @@ type Feature struct {
 
 	// Dependencies is a list of feature toggle dependency objects
 	Dependencies *[]Dependency `json:"dependencies"`
+
+	// ImpressionData indicates whether the client SDK should emit an impression event
+	ImpressionData bool `json:"impressionData"`
 }
 
 type Dependency struct {


### PR DESCRIPTION
## About the changes

Currently, there is no way to access "impressionData" property on the feature object, as it is not exposed via `Feature` type, so there is no way to implement "impressions" logic based on boolean flag that is set on per-feature basis. 
