### PR TITLE
feat: client identification headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -169,9 +169,9 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 	if uc.options.customHeaders != nil {
 		headers = uc.options.customHeaders
 	}
-	headers.Set("x-unleash-appname", uc.options.appName)
-	headers.Set("x-unleash-sdk", fmt.Sprintf("%s:%s", clientName, clientVersion))
-	headers.Set("x-unleash-connection-id", getConnectionId())
+	headers.Set("unleash-appname", uc.options.appName)
+	headers.Set("unleash-sdk", fmt.Sprintf("%s:%s", clientName, clientVersion))
+	headers.Set("unleash-connection-id", getConnectionId())
 
 	uc.repository = newRepository(
 		repositoryOptions{

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package unleash
 import (
 	"fmt"
 
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -164,7 +165,10 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		uc.options.instanceId = generateInstanceId()
 	}
 
-	headers := uc.options.customHeaders
+	headers := make(http.Header)
+	if uc.options.customHeaders != nil {
+		headers = uc.options.customHeaders
+	}
 	headers.Set("x-unleash-appname", uc.options.appName)
 	headers.Set("x-unleash-sdk", fmt.Sprintf("%s:%s", clientName, clientVersion))
 	headers.Set("x-unleash-connection-id", getConnectionId())

--- a/client.go
+++ b/client.go
@@ -164,6 +164,11 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		uc.options.instanceId = generateInstanceId()
 	}
 
+	headers := uc.options.customHeaders
+	headers.Set("x-unleash-appname", uc.options.appName)
+	headers.Set("x-unleash-sdk", fmt.Sprintf("%s:%s", clientName, clientVersion))
+	headers.Set("x-unleash-connection-id", getConnectionId())
+
 	uc.repository = newRepository(
 		repositoryOptions{
 			backupPath:      uc.options.backupPath,
@@ -174,7 +179,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			refreshInterval: uc.options.refreshInterval,
 			storage:         uc.options.storage,
 			httpClient:      uc.options.httpClient,
-			customHeaders:   uc.options.customHeaders,
+			headers:         headers,
 		},
 		repositoryChannels{
 			errorChannels: errChannels,
@@ -197,7 +202,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			metricsInterval: uc.options.metricsInterval,
 			url:             *parsedUrl,
 			httpClient:      uc.options.httpClient,
-			customHeaders:   uc.options.customHeaders,
+			headers:         headers,
 			disableMetrics:  uc.options.disableMetrics,
 		},
 		metricsChannels{

--- a/client_test.go
+++ b/client_test.go
@@ -1424,16 +1424,16 @@ func TestSendIdentificationHeaders(t *testing.T) {
 
 	gock.New(mockerServer).
 		Post("/client/register").
-		MatchHeader("X-UNLEASH-APPNAME", mockAppName).
-		MatchHeader("X-UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
-		MatchHeader("X-UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
+		MatchHeader("UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
 		Reply(200)
 
 	gock.New(mockerServer).
 		Get("/client/features").
-		MatchHeader("X-UNLEASH-APPNAME", mockAppName).
-		MatchHeader("X-UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
-		MatchHeader("X-UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
+		MatchHeader("UNLEASH-APPNAME", mockAppName).
+		MatchHeader("UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
+		MatchHeader("UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
 		Reply(200).
 		JSON(api.FeatureResponse{})
 

--- a/client_test.go
+++ b/client_test.go
@@ -1417,3 +1417,36 @@ func TestGetVariant_FallbackVariantFeatureEnabledSettingIsLeftUnchanged(t *testi
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
+
+func TestSendIdentificationHeaders(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		MatchHeader("X-UNLEASH-APPNAME", mockAppName).
+		MatchHeader("X-UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
+		MatchHeader("X-UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
+		Reply(200)
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		MatchHeader("X-UNLEASH-APPNAME", mockAppName).
+		MatchHeader("X-UNLEASH-SDK", `unleash-client-go:\d+\.\d+\.\d+`).
+		MatchHeader("X-UNLEASH-CONNECTION-ID", `[0-9a-f\-]{36}`).
+		Reply(200).
+		JSON(api.FeatureResponse{})
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(&NoopListener{}),
+	)
+
+	assert.NoError(err)
+
+	client.WaitForReady()
+
+	assert.True(gock.IsDone(), "there should be no more mocks")
+}

--- a/config.go
+++ b/config.go
@@ -253,7 +253,7 @@ type repositoryOptions struct {
 	refreshInterval time.Duration
 	storage         Storage
 	httpClient      *http.Client
-	customHeaders   http.Header
+	headers         http.Header
 }
 
 type metricsOptions struct {
@@ -264,6 +264,6 @@ type metricsOptions struct {
 	metricsInterval time.Duration
 	disableMetrics  bool
 	httpClient      *http.Client
-	customHeaders   http.Header
+	headers         http.Header
 	started         *time.Time
 }

--- a/metrics.go
+++ b/metrics.go
@@ -259,7 +259,7 @@ func (m *metrics) doPost(url *url.URL, payload interface{}) (*http.Response, err
 	req.Header.Add("UNLEASH-INSTANCEID", m.options.instanceId)
 	req.Header.Add("User-Agent", m.options.appName)
 
-	for k, v := range m.options.customHeaders {
+	for k, v := range m.options.headers {
 		req.Header[k] = v
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -130,7 +130,7 @@ func (r *repository) fetch() error {
 	// global segments
 	req.Header.Add("Unleash-Client-Spec", SEGMENT_CLIENT_SPEC_VERSION)
 
-	for k, v := range r.options.customHeaders {
+	for k, v := range r.options.headers {
 		req.Header[k] = v
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -31,6 +31,8 @@ func generateInstanceId() string {
 	return prefix
 }
 
+// https://github.com/google/uuid/blob/2d3c2a9cc518326daf99a383f07c4d3c44317e4d/version4.go#L47-L56
+// https://github.com/hprose/hprose-go/blob/83de97da5004027694d321ca38c80fca3fac98c2/uuid.go#L91-L98
 func getConnectionId() string {
 	b := make([]byte, 16)
 	cryptoRand.Read(b)

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package unleash
 
 import (
+	cryptoRand "crypto/rand"
 	"fmt"
 	"math/rand"
 	"os"
@@ -28,6 +29,24 @@ func generateInstanceId() string {
 		return fmt.Sprintf("%s-%s", prefix, hostname)
 	}
 	return prefix
+}
+
+func getConnectionId() string {
+	b := make([]byte, 16)
+	cryptoRand.Read(b)
+
+	b[6] = (b[6] & 0x0F) | 0x40
+	b[8] = (b[8] & 0x3F) | 0x80
+
+	uuid := fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4],
+		b[4:6],
+		b[6:8],
+		b[8:10],
+		b[10:16],
+	)
+
+	return uuid
 }
 
 func getFetchURLPath(projectName string) string {

--- a/utils_test.go
+++ b/utils_test.go
@@ -116,3 +116,35 @@ func TestContains(t *testing.T) {
 		}
 	})
 }
+
+func TestGetConnectionId(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		uuid := getConnectionId()
+
+		t.Run("Correct length", func(t *testing.T) {
+			if len(uuid) != 36 {
+				t.Errorf("Expected UUID length to be 36, but got %d in %s", len(uuid), uuid)
+			}
+		})
+
+		t.Run("UUIDv4 version", func(t *testing.T) {
+			if uuid[14] != '4' {
+				t.Errorf("Expected version 4, but got %c in %s", uuid[14], uuid)
+			}
+		})
+
+		t.Run("UUIDv4 variant", func(t *testing.T) {
+			variant := uuid[19]
+			if variant != '8' && variant != '9' && variant != 'a' && variant != 'b' {
+				t.Errorf("Expected variant 10xx, but got %c in %s", variant, uuid)
+			}
+		})
+
+		t.Run("Uniqueness", func(t *testing.T) {
+			uuid2 := getConnectionId()
+			if uuid == uuid2 {
+				t.Errorf("Generated UUIDs are not unique: '%s' and '%s'", uuid, uuid2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Identification headers consistent with other Unleash SDKs.

> This PR adds standardized client identification headers to the feature and metrics calls that the client makes to Unleash. The headers are:
> - `unleash-appname`: the name of the application that is using the client. `UNLEASH-APPNAME` will be deleted in another PR (expand/contract pattern)
> - `unleash-connection-id`: an internal unique identifier for the current instance of the client generated by the built-in crypto lib
> - `unleash-sdk`: sdk information in the format `unleash-client-<language>:<version>`
> 
> All the headers are intended for the Unleash team. Changes should be implemented in a way that does not change SDK behavior in a significant way.
> The main use cases we have are:
> * capacity planning by knowing the number of unique connections made to the backend API
> * debugging misconfigured SDKs sending more traffic than expected

Fixes [issue/1-3271](https://linear.app/unleash/issue/1-3271/uniqueness-headers-in-go-sdk)