### PR TITLE
chore: bump to 4.4.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 const (
 	deprecatedSuffix = "/features"
 	clientName       = "unleash-client-go"
-	clientVersion    = "4.3.0"
+	clientVersion    = "4.4.0"
 	specVersion      = "4.3.1"
 )
 


### PR DESCRIPTION
Bumps to 4.4.0 to prepare for a new release.