### PR TITLE
Add support for OnUpdate hook

### DIFF
--- a/client.go
+++ b/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	repositoryListener RepositoryListener
 	ready              chan bool
 	onReady            chan struct{}
+	update             chan bool
 	close              chan struct{}
 	closed             chan struct{}
 	count              chan metric
@@ -76,7 +77,8 @@ func (ec errorChannels) err(err error) {
 
 type repositoryChannels struct {
 	errorChannels
-	ready chan bool
+	ready  chan bool
+	update chan bool
 }
 
 type metricsChannels struct {
@@ -106,6 +108,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		errorChannels: errChannels,
 		onReady:       make(chan struct{}),
 		ready:         make(chan bool, 1),
+		update:        make(chan bool, 1),
 		count:         make(chan metric),
 		sent:          make(chan MetricsData),
 		registered:    make(chan ClientData, 1),
@@ -190,6 +193,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		repositoryChannels{
 			errorChannels: errChannels,
 			ready:         uc.ready,
+			update:        uc.update,
 		},
 	)
 
@@ -239,6 +243,10 @@ func (uc *Client) sync() {
 			if uc.repositoryListener != nil {
 				uc.repositoryListener.OnReady()
 			}
+		case <-uc.update:
+			if uc.repositoryListener != nil {
+				uc.repositoryListener.OnUpdate()
+			}
 		case m := <-uc.count:
 			if uc.metricsListener != nil {
 				uc.metricsListener.OnCount(m.Name, m.Enabled)
@@ -252,6 +260,7 @@ func (uc *Client) sync() {
 				uc.metricsListener.OnRegistered(cd)
 			}
 		case <-uc.close:
+			close(uc.update)
 			close(uc.closed)
 			return
 		}

--- a/debuglistener.go
+++ b/debuglistener.go
@@ -24,6 +24,11 @@ func (l DebugListener) OnReady() {
 	fmt.Printf("READY\n")
 }
 
+// OnUpdate prints to the console when the repository is updated.
+func (l DebugListener) OnUpdate() {
+	fmt.Printf("UPDATE\n")
+}
+
 // OnCount prints to the console when the feature is queried.
 func (l DebugListener) OnCount(name string, enabled bool) {
 	fmt.Printf("Counted '%s'  as enabled? %v\n", name, enabled)

--- a/nooplistener.go
+++ b/nooplistener.go
@@ -15,6 +15,10 @@ func (l NoopListener) OnWarning(warning error) {
 func (l NoopListener) OnReady() {
 }
 
+// The repository was refreshed.
+func (l NoopListener) OnUpdate() {
+}
+
 // The feature is queried.
 func (l NoopListener) OnCount(name string, enabled bool) {
 }

--- a/repository.go
+++ b/repository.go
@@ -73,6 +73,8 @@ func (r *repository) fetchAndReportError() {
 	if !r.isReady && err == nil {
 		r.isReady = true
 		r.ready <- true
+	} else if err == nil {
+		r.update <- true
 	}
 }
 

--- a/repository.go
+++ b/repository.go
@@ -3,6 +3,7 @@ package unleash
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -14,6 +15,10 @@ import (
 )
 
 var SEGMENT_CLIENT_SPEC_VERSION = "4.3.1"
+
+var (
+	errNoChange = errors.New("no change")
+)
 
 type repository struct {
 	repositoryChannels
@@ -64,16 +69,29 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 }
 
 func (r *repository) fetchAndReportError() {
-	err := r.fetch()
+	var (
+		isUnchanged bool
+		err         error
+	)
+
+	err = r.fetch()
+
+	// Extract unchanged error from error
+	if err != nil {
+		isUnchanged = errors.Is(err, errNoChange)
+		if isUnchanged {
+			err = nil
+		}
+	}
+
 	if err != nil {
 		if urlErr, ok := err.(*url.Error); !(ok && urlErr.Err == context.Canceled) {
 			r.err(err)
 		}
-	}
-	if !r.isReady && err == nil {
+	} else if !r.isReady {
 		r.isReady = true
 		r.ready <- true
-	} else if err == nil {
+	} else if !isUnchanged {
 		r.update <- true
 	}
 }
@@ -149,7 +167,7 @@ func (r *repository) fetch() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotModified {
-		return nil
+		return errNoChange
 	}
 	if err := r.statusIsOK(resp); err != nil {
 		return err

--- a/unleash.go
+++ b/unleash.go
@@ -33,6 +33,10 @@ type RepositoryListener interface {
 	// OnReady is called when the client has loaded the feature toggles from
 	// the Unleash server.
 	OnReady()
+
+	// OnUpdate is called each time the client has loaded the features toggles from
+	// the Unleash server after the initial request.
+	OnUpdate()
 }
 
 // IsEnabled queries the default client whether or not the specified feature is enabled or not.

--- a/unleash_mock.go
+++ b/unleash_mock.go
@@ -29,6 +29,10 @@ func (l *MockedListener) OnReady() {
 	l.Called()
 }
 
+func (l *MockedListener) OnUpdate() {
+	l.Called()
+}
+
 func (l *MockedListener) OnCount(name string, enabled bool) {
 	l.Called(name, enabled)
 }


### PR DESCRIPTION
This is what I believe were the requested changes in https://github.com/Unleash/unleash-client-go/pull/193. It also addresses some (what I believe to be) issues in the original PR, such as the unnecessary declaration and assignment of the `onUpdate` channel. The only required channel is the `update` channel that was actually implemented.

The original issue addressed by this PR is #192.

I'm posting the original PR description below.

---

> ### Describe the feature request
> 
> I am attempting to support switching the log level for my application via an unleash flag. However unless there is a different approach to dealing with update hooks besides implementing my own timer, I am overlooking it.
> 
> I would like to use a callback such as OnChange or even OnUpdate to detect when flags are modified instead of testing for the flag in every log call regardless of the metrics.
> 
> Do you have any ideas on how to approach this?
> ### Background
> 
> _No response_
> ### Solution suggestions
> 
> _No response_