### PR TITLE
chore(version): Bump to 4.5.0 to prepare for release

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 const (
 	deprecatedSuffix = "/features"
 	clientName       = "unleash-client-go"
-	clientVersion    = "4.4.0"
+	clientVersion    = "4.5.0"
 	specVersion      = "4.3.1"
 )
 


### PR DESCRIPTION
As the title says. After adding the OnUpdate hook we want a new minor release