### PR TITLE
fix: Client.Ready() blocks forever when called after client is already ready

### DIFF
--- a/client.go
+++ b/client.go
@@ -548,11 +548,17 @@ func (uc *Client) Warnings() <-chan error {
 	return uc.warnings
 }
 
-// Ready returns the ready channel for the client. A value will be available on
-// the channel when the feature toggles have been loaded from the Unleash
-// server.
+// Ready returns a channel that will receive `true` when the client has loaded
+// feature toggles from the Unleash server. It returns a fresh channel per call
+// and will deliver immediately if the client is already ready.
 func (uc *Client) Ready() <-chan bool {
-	return uc.ready
+	ch := make(chan bool, 1)
+	go func() {
+		<-uc.onReady
+		ch <- true
+		close(ch)
+	}()
+	return ch
 }
 
 // Count returns the count channel which gives an update when a toggle has been queried.

--- a/client_test.go
+++ b/client_test.go
@@ -1496,3 +1496,86 @@ func TestConnectionAndIntervalHeadersAndBody(t *testing.T) {
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
+
+func TestReady(t *testing.T) {
+	// waitReadyChannelWithTimeout is a safety net for waiting on the ready channel to send the ready state.
+	// In the worst case, if the channel never sends anything after this subscribe, this function will time out and fail the test.
+	waitReadyChannelWithTimeout := func(t *testing.T, ready <-chan bool) (bool, bool) {
+		t.Helper()
+		select {
+		case actual, ok := <-ready:
+			return actual, ok
+		case <-time.After(100 * time.Millisecond):
+			t.Error("timeout waiting for unleash client to be ready after 100ms")
+		}
+		return false, false
+	}
+
+	t.Run("call ready", func(t *testing.T) {
+		assert := assert.New(t)
+		defer gock.OffAll()
+
+		gock.New(mockerServer).
+			Get("/client/features").
+			Reply(200).
+			JSON(api.FeatureResponse{})
+
+		mockListener := &MockedListener{}
+		mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+		mockListener.On("OnReady").Return()
+
+		client, err := NewClient(
+			WithUrl(mockerServer),
+			WithAppName(mockAppName),
+			WithInstanceId(mockInstanceId),
+			WithListener(mockListener),
+			WithDisableMetrics(true),
+		)
+		assert.NoError(err)
+
+		ready, ok := waitReadyChannelWithTimeout(t, client.Ready())
+		assert.True(ready, "the ready should be true when client has synced the feature flags")
+		assert.True(ok)
+
+		err = client.Close()
+
+		assert.True(gock.IsDone(), "there should be no more mocks")
+	})
+
+	t.Run("call Ready again after client is ready", func(t *testing.T) {
+		assert := assert.New(t)
+		defer gock.OffAll()
+
+		gock.New(mockerServer).
+			Get("/client/features").
+			Reply(200).
+			JSON(api.FeatureResponse{})
+
+		mockListener := &MockedListener{}
+		mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+		mockListener.On("OnReady").Return()
+
+		client, err := NewClient(
+			WithUrl(mockerServer),
+			WithAppName(mockAppName),
+			WithInstanceId(mockInstanceId),
+			WithListener(mockListener),
+			WithDisableMetrics(true),
+		)
+		assert.NoError(err)
+
+		ready, ok := waitReadyChannelWithTimeout(t, client.Ready())
+		assert.True(ready, "the ready should be true when client has synced the feature flags")
+		assert.True(ok)
+
+		// Issue since v5.0.3 and below.
+		// If client is ready after client.Ready is called, The ready channel return nothing and it will be stuck
+		ready, ok = waitReadyChannelWithTimeout(t, client.Ready())
+		assert.True(ready, "the ready should remain true even if the ready channel has already broadcast the ready state.")
+		assert.True(ok)
+
+		err = client.Close()
+
+		assert.True(gock.IsDone(), "there should be no more mocks")
+	})
+}


### PR DESCRIPTION
<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->
Client.Ready() no longer exposes the internal one-shot `uc.ready` channel. It now returns a fresh channel per call that resolves by waiting on `uc.onReady` (a close-only broadcast). This ensures `Ready()` delivers even when called after the client has already become ready.

  - Affected versions: v5.0.3 and earlier
  - Unaffected APIs: `WaitForReady()` and listener callbacks

<!-- Does it close an issue? Multiple? -->
Closes #203

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
- `client.go` — change to `Ready()` to use `uc.onReady` and per-call channel.
- `client_test.go` — tests for initial and post-ready calls with timeouts.


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
- Currently repository (and in streaming, the delta processor) can signal readiness into `uc.ready` more than once. Closing uc.onReady once makes duplicate sources harmless, but confirm this is the intended single “ready” moment across modes.
- Returning a fresh channel per call changes channel identity. Unlikely anyone relied on the old identity, but it follows the functionality from docs.