### PR TITLE
fix: unleash.Initialize() method does not return error if client creation fails 

### DIFF
--- a/unleash.go
+++ b/unleash.go
@@ -61,7 +61,7 @@ func IsEnabled(feature string, options ...FeatureOption) bool {
 // Initialize will specify the options to be used by the default client.
 func Initialize(options ...ConfigOption) (err error) {
 	defaultClient, err = NewClient(options...)
-	return
+	return err
 }
 
 func GetVariant(feature string, options ...VariantOption) *api.Variant {


### PR DESCRIPTION
This PR updates the Initialize function to properly return errors from NewClient.
Previously, Initialize would just return immediately, leaving it unclear whether the client was successfully initialized or if there was a connection/configuration issue.

With this change, callers of Initialize can now handle initialization errors gracefully.

Important files

unleash.go (updated Initialize function)

closes #205
Discussion points

Should we also consider adding a health check (pinging the Unleash server) during initialization, or is propagating the error enough for now?