### PR TITLE
chore: don't emit metrics event when it isn't needed

### DIFF
--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		onReady:       make(chan struct{}),
 		ready:         make(chan bool, 1),
 		update:        make(chan bool, 1),
-		count:         make(chan metric),
+		count:         make(chan metric, 65536),
 		sent:          make(chan MetricsData),
 		registered:    make(chan ClientData, 1),
 		impression:    make(chan ImpressionEvent, 10),
@@ -128,6 +128,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		AppName:     uc.options.appName,
 	}
 
+	emitMetricCounts := uc.options.listener != nil
 	if uc.options.listener == nil {
 		uc.options.listener = &NoopListener{}
 	}
@@ -214,15 +215,16 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 
 	uc.metrics = newMetrics(
 		metricsOptions{
-			appName:         uc.options.appName,
-			instanceId:      uc.options.instanceId,
-			connectionId:    connectionId,
-			strategies:      strategyNames,
-			metricsInterval: uc.options.metricsInterval,
-			url:             *parsedUrl,
-			httpClient:      uc.options.httpClient,
-			headers:         headers,
-			disableMetrics:  uc.options.disableMetrics,
+			appName:          uc.options.appName,
+			instanceId:       uc.options.instanceId,
+			connectionId:     connectionId,
+			strategies:       strategyNames,
+			metricsInterval:  uc.options.metricsInterval,
+			url:              *parsedUrl,
+			httpClient:       uc.options.httpClient,
+			headers:          headers,
+			disableMetrics:   uc.options.disableMetrics,
+			emitMetricCounts: emitMetricCounts,
 		},
 		metricsChannels{
 			errorChannels: errChannels,

--- a/config.go
+++ b/config.go
@@ -266,20 +266,21 @@ type repositoryOptions struct {
 	backupPath      string
 	refreshInterval time.Duration
 	storage         Storage
-	httpClient     	*http.Client
+	httpClient      *http.Client
 	headers         http.Header
 	isStreaming     bool
 }
 
 type metricsOptions struct {
-	appName         string
-	instanceId      string
-	connectionId    string
-	url             url.URL
-	strategies      []string
-	metricsInterval time.Duration
-	disableMetrics  bool
-	httpClient      *http.Client
-	headers         http.Header
-	started         *time.Time
+	appName          string
+	instanceId       string
+	connectionId     string
+	url              url.URL
+	strategies       []string
+	metricsInterval  time.Duration
+	disableMetrics   bool
+	httpClient       *http.Client
+	headers          http.Header
+	started          *time.Time
+	emitMetricCounts bool
 }

--- a/metrics.go
+++ b/metrics.go
@@ -89,30 +89,32 @@ type metric struct {
 
 type metrics struct {
 	metricsChannels
-	options  metricsOptions
-	started  time.Time
-	bucketMu sync.Mutex
-	bucket   api.Bucket
-	ticker   *time.Ticker
-	close    chan struct{}
-	closed   chan struct{}
-	ctx      context.Context
-	cancel   func()
-	maxSkips float64
-	errors   float64
-	skips    float64
+	options          metricsOptions
+	started          time.Time
+	bucketMu         sync.Mutex
+	bucket           api.Bucket
+	ticker           *time.Ticker
+	close            chan struct{}
+	closed           chan struct{}
+	ctx              context.Context
+	cancel           func()
+	maxSkips         float64
+	errors           float64
+	skips            float64
+	emitMetricCounts bool
 }
 
 func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 	m := &metrics{
-		metricsChannels: channels,
-		options:         options,
-		started:         time.Now(),
-		close:           make(chan struct{}),
-		closed:          make(chan struct{}),
-		maxSkips:        10,
-		errors:          0,
-		skips:           0,
+		metricsChannels:  channels,
+		options:          options,
+		started:          time.Now(),
+		close:            make(chan struct{}),
+		closed:           make(chan struct{}),
+		maxSkips:         10,
+		errors:           0,
+		skips:            0,
+		emitMetricCounts: options.emitMetricCounts,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	m.ctx = ctx
@@ -299,7 +301,9 @@ func (m *metrics) count(name string, enabled bool) {
 		return
 	}
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	if m.emitMetricCounts {
+		m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	}
 }
 
 func (m *metrics) countVariants(name string, enabled bool, variantName string) {


### PR DESCRIPTION
Currently merging into the wrong branch so we can see a nice diff.

This is a little hack to not emit metrics events when they're not actually listened to. Improves the performance under load for p50 -> p99 by about 2 orders of magnitude 