### PR TITLE
Chore/remove build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.21, 1.22, 1.23, 1.24]
+        version: [1.22, 1.23, 1.24, 1.25]
     steps:
       - uses: actions/checkout@v4
         name: Checkout code


### PR DESCRIPTION
Removes 1.21 as a build target now that we are using math/rand/v2. Adds 1.25.