### PR TITLE
fix: use sync pool for strategy randomness

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -86,12 +86,12 @@ func (fr FeatureResponse) SegmentsMap() map[int][]Constraint {
 }
 
 // Get variant for a given feature which is considered as enabled
-func (vc VariantCollection) GetVariant(ctx *context.Context) *Variant {
+func (vc VariantCollection) GetVariant(ctx *context.Context, stickinessOverride *string) *Variant {
 	if len(vc.Variants) > 0 {
 		v := vc.getOverrideVariant(ctx)
 		var variant *Variant
 		if v == nil {
-			variant = vc.getVariantFromWeights(ctx)
+			variant = vc.getVariantFromWeights(ctx, stickinessOverride)
 		} else {
 			variant = &v.Variant
 		}
@@ -102,7 +102,7 @@ func (vc VariantCollection) GetVariant(ctx *context.Context) *Variant {
 	return DISABLED_VARIANT
 }
 
-func (vc VariantCollection) getVariantFromWeights(ctx *context.Context) *Variant {
+func (vc VariantCollection) getVariantFromWeights(ctx *context.Context, stickinessOverride *string) *Variant {
 	totalWeight := 0
 	for _, variant := range vc.Variants {
 		totalWeight += variant.Weight
@@ -110,7 +110,11 @@ func (vc VariantCollection) getVariantFromWeights(ctx *context.Context) *Variant
 	if totalWeight == 0 {
 		return DISABLED_VARIANT
 	}
+
 	stickiness := vc.Variants[0].Stickiness
+	if stickinessOverride != nil {
+		stickiness = *stickinessOverride
+	}
 
 	target := strategies.NormalizedVariantValue(getSeed(ctx, stickiness), vc.GroupId, totalWeight, strategies.VariantNormalizationSeed)
 	counter := uint32(0)

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -132,7 +132,7 @@ func (suite *VariantTestSuite) TestGetVariantWhenFeatureHasNoVariant() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 
 	suite.Equal(DISABLED_VARIANT, variantSetup, "Should return default variant")
 }
@@ -155,7 +155,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnUserId() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarA", variantSetup.Name, "Should return VarA")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -178,7 +178,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnRemoteAddress() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarB", variantSetup.Name, "Should return VarB")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -202,7 +202,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnSessionId() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarA", variantSetup.Name, "Should return VarA")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -226,7 +226,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnCustomProperties() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarC", variantSetup.Name, "Should return VarC")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -244,7 +244,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarD() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -261,7 +261,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarE() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarF", variantSetup.Name, "Should return VarF")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -278,7 +278,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarF() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -304,7 +304,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnAppName() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -326,7 +326,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnEnvironment() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")

--- a/client.go
+++ b/client.go
@@ -431,7 +431,7 @@ func (uc *Client) getVariantWithoutMetrics(feature string, snapshot *FeatureMemo
 	return api.VariantCollection{
 		GroupId:  f.Name,
 		Variants: f.Variants,
-	}.GetVariant(ctx)
+	}.GetVariant(ctx, nil)
 }
 
 // Close stops the client from syncing data from the server.

--- a/client_test.go
+++ b/client_test.go
@@ -59,7 +59,7 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -103,7 +103,7 @@ func TestClient_WithResolver(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -335,7 +335,7 @@ func TestClientWithVariantContext(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -424,7 +424,7 @@ func TestClient_WithSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -502,7 +502,7 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, false).Return()
+	mockListener.On("OnCount", feature, false).Maybe()
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
 	client, err := NewClient(
@@ -606,7 +606,7 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -721,7 +721,7 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -839,7 +839,7 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError").Return()
 
@@ -942,7 +942,7 @@ func TestClient_ShouldFavorStrategyVariantOverFeatureVariant(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1042,7 +1042,7 @@ func TestClient_ShouldReturnOldVariantForNonMatchingStrategyVariant(t *testing.T
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1106,7 +1106,7 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(

--- a/feature_state.go
+++ b/feature_state.go
@@ -81,12 +81,20 @@ func (s *FeatureMemoryState) evaluateFeature(
 				}, fmt.Errorf("invalid groupId type for feature %s", f.Name)
 			}
 
+			var stickiness *string
+
+			if v, ok := stCfg.Parameters[strategy.ParamStickiness]; ok {
+				if s, ok := v.(string); ok {
+					stickiness = &s
+				}
+			}
+
 			return api.StrategyResult{
 				Enabled: true,
 				Variant: api.VariantCollection{
 					GroupId:  groupId,
 					Variants: stCfg.Variants,
-				}.GetVariant(ctx),
+				}.GetVariant(ctx, stickiness),
 			}, nil
 		}
 

--- a/impression_test.go
+++ b/impression_test.go
@@ -58,7 +58,7 @@ func TestImpression_Off(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.Anything).Maybe()
 
 	client := setupClient(t, mockListener)
@@ -107,7 +107,7 @@ func TestImpression_IsEnabled(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -178,7 +178,7 @@ func TestImpression_GetVariant(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -247,7 +247,7 @@ func TestImpression_WithContext(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	userCtx := context.Context{
 		UserId:    ctxUserId,
@@ -411,7 +411,7 @@ func TestImpression_GetChannelMethod(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.AnythingOfType("ImpressionEvent")).Maybe()
 	mockListener.On("OnError", mock.Anything).Maybe()
 

--- a/internal/strategies/flexible_rollout.go
+++ b/internal/strategies/flexible_rollout.go
@@ -31,9 +31,9 @@ func (s flexibleRolloutStrategy) Name() string {
 func (s flexibleRolloutStrategy) resolveStickiness(st stickiness, ctx context.Context) string {
 	switch st {
 	case defaultStickiness:
-		return coalesce(ctx.UserId, ctx.SessionId, s.random.string())
+		return coalesce(ctx.UserId, ctx.SessionId, randomString())
 	case randomStickiness:
-		return s.random.string()
+		return randomString()
 	default:
 		return ctx.Field(string(st))
 	}

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -89,3 +89,18 @@ func (r *rng) string() string {
 func newRng() *rng {
 	return &rng{random: rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(os.Getpid())))}
 }
+
+var rngPool = sync.Pool{
+	New: func() any {
+		seed := time.Now().UnixNano() + int64(os.Getpid())
+		return rand.New(rand.NewSource(seed))
+	},
+}
+
+func randomString() string {
+	r := rngPool.Get().(*rand.Rand)
+	n := r.Intn(10000) + 1
+	rngPool.Put(r)
+
+	return strconv.Itoa(n)
+}

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -92,14 +92,13 @@ func newRng() *rng {
 
 var rngPool = sync.Pool{
 	New: func() any {
-		seed := time.Now().UnixNano() + int64(os.Getpid())
-		return rand.New(rand.NewSource(seed))
+		return rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(os.Getpid())))
 	},
 }
 
 func randomString() string {
 	r := rngPool.Get().(*rand.Rand)
-	n := r.Intn(10000) + 1
+	n := r.IntN(10000) + 1
 	rngPool.Put(r)
 
 	return strconv.Itoa(n)

--- a/metrics.go
+++ b/metrics.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v5/internal/api"
@@ -87,20 +88,28 @@ type metric struct {
 	Enabled bool
 }
 
+type toggleCounters struct {
+	yes int64
+	no  int64
+
+	mu       sync.Mutex
+	variants map[string]int64
+}
+
 type metrics struct {
 	metricsChannels
-	options  metricsOptions
-	started  time.Time
-	bucketMu sync.Mutex
-	bucket   api.Bucket
-	ticker   *time.Ticker
-	close    chan struct{}
-	closed   chan struct{}
-	ctx      context.Context
-	cancel   func()
-	maxSkips float64
-	errors   float64
-	skips    float64
+	options       metricsOptions
+	started       time.Time
+	lastCloseTime time.Time
+	counters      sync.Map // map[string]*toggleCounters
+	ticker        *time.Ticker
+	close         chan struct{}
+	closed        chan struct{}
+	ctx           context.Context
+	cancel        func()
+	maxSkips      float64
+	errors        float64
+	skips         float64
 }
 
 func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
@@ -113,6 +122,7 @@ func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 		maxSkips:        10,
 		errors:          0,
 		skips:           0,
+		lastCloseTime:   time.Now(),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	m.ctx = ctx
@@ -122,7 +132,6 @@ func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 		m.options.httpClient = http.DefaultClient
 	}
 
-	m.resetBucket()
 	if m.options.metricsInterval <= 0 {
 		m.options.disableMetrics = true
 	}
@@ -196,13 +205,70 @@ func (m *metrics) successfulPost() {
 func (m *metrics) decrementSkip() {
 	m.skips = math.Max(0, m.skips-1)
 }
+
+// This does not remove stale toggle names from the map. I don't think there's a safe, lock free way to do that
+// The consequence is that if the user archives a lot of toggles this internal representation will not lose those
+// toggles until the process is terminated. In practice, I don't believe this is a big problem, just means a
+// little bit more memory is held than necessary
+func (m *metrics) buildBucketAndReset(lastCloseTime time.Time) (api.Bucket, bool) {
+	bucket := api.Bucket{
+		Start:   lastCloseTime,
+		Toggles: make(map[string]api.ToggleCount),
+	}
+
+	m.counters.Range(func(key, value any) bool {
+		name := key.(string)
+		counter := value.(*toggleCounters)
+
+		yes := atomic.SwapInt64(&counter.yes, 0)
+		no := atomic.SwapInt64(&counter.no, 0)
+
+		if yes == 0 && no == 0 {
+			counter.mu.Lock()
+			emptyVariants := len(counter.variants) == 0
+			counter.mu.Unlock()
+			if emptyVariants {
+				return true
+			}
+		}
+
+		toggleCounters := api.ToggleCount{
+			Yes: int32(yes),
+			No:  int32(no),
+		}
+
+		// we can have a little locking, as a treat. Variants are likely a luke warm path at best
+		// until we have evidence that this is a hot path API, I'd like to keep this simple
+		// simple here means a local lock per toggle counter while we swap out the variants map
+		counter.mu.Lock()
+		if len(counter.variants) > 0 {
+			vars := make(map[string]int32, len(counter.variants))
+			for vName, cnt := range counter.variants {
+				vars[vName] = int32(cnt)
+			}
+			toggleCounters.Variants = vars
+
+			counter.variants = make(map[string]int64)
+		}
+		counter.mu.Unlock()
+
+		bucket.Toggles[name] = toggleCounters
+		return true
+	})
+
+	if len(bucket.Toggles) == 0 {
+		return api.Bucket{}, false
+	}
+
+	return bucket, true
+}
+
 func (m *metrics) sendMetrics() {
-	m.bucketMu.Lock()
-	bucket := m.resetBucket()
-	m.bucketMu.Unlock()
-	if bucket.IsEmpty() {
+	bucket, ok := m.buildBucketAndReset(m.lastCloseTime)
+	if !ok {
 		return
 	}
+	m.lastCloseTime = time.Now()
 	bucket.Stop = time.Now()
 	payload := MetricsData{
 		AppName:          m.options.appName,
@@ -233,23 +299,19 @@ func (m *metrics) sendMetrics() {
 		m.warn(fmt.Errorf("%s return %d", u.String(), resp.StatusCode))
 		// The post failed, re-add the metrics we attempted to send so
 		// they are included in the next post.
-		for name, tc := range bucket.Toggles {
-			m.add(name, true, tc.Yes)
-			m.add(name, false, tc.No)
-		}
+		m.reinsertBucket(bucket)
 
-		m.bucketMu.Lock()
 		// Set the start time of the current bucket to the one we
 		// attempted to send.
-		m.bucket.Start = bucket.Start
-		m.bucketMu.Unlock()
+		m.lastCloseTime = bucket.Start
+
 	} else {
 		m.successfulPost()
 		m.sent <- payload
 	}
 }
 
-func (m *metrics) doPost(url *url.URL, payload any) (*http.Response, error) {
+func (m *metrics) doPost(url *url.URL, payload interface{}) (*http.Response, error) {
 	var body bytes.Buffer
 	enc := json.NewEncoder(&body)
 	if err := enc.Encode(payload); err != nil {
@@ -274,24 +336,55 @@ func (m *metrics) doPost(url *url.URL, payload any) (*http.Response, error) {
 	return m.options.httpClient.Do(req)
 }
 
+func (m *metrics) getOrCreateCounter(name string) *toggleCounters {
+	c, ok := m.counters.Load(name)
+	if ok {
+		return c.(*toggleCounters)
+	}
+
+	nc := &toggleCounters{
+		variants: make(map[string]int64),
+	}
+	actual, _ := m.counters.LoadOrStore(name, nc)
+	return actual.(*toggleCounters)
+}
+
+func (m *metrics) reinsertBucket(bucket api.Bucket) {
+	for name, bucketToggle := range bucket.Toggles {
+		counter := m.getOrCreateCounter(name)
+		if bucketToggle.Yes != 0 {
+			atomic.AddInt64(&counter.yes, int64(bucketToggle.Yes))
+		}
+		if bucketToggle.No != 0 {
+			atomic.AddInt64(&counter.no, int64(bucketToggle.No))
+		}
+
+		if len(bucketToggle.Variants) > 0 {
+			counter.mu.Lock()
+			if counter.variants == nil {
+				counter.variants = make(map[string]int64, len(bucketToggle.Variants))
+			}
+			for vName, cnt := range bucketToggle.Variants {
+				if cnt == 0 {
+					continue
+				}
+				counter.variants[vName] += int64(cnt)
+			}
+			counter.mu.Unlock()
+		}
+	}
+}
+
 func (m *metrics) add(name string, enabled bool, num int32) {
 	if m.options.disableMetrics || num == 0 {
 		return
 	}
-	m.bucketMu.Lock()
-	defer m.bucketMu.Unlock()
-	t, exists := m.bucket.Toggles[name]
-	if !exists {
-		t = api.ToggleCount{
-			Variants: map[string]int32{},
-		}
-	}
+	c := m.getOrCreateCounter(name)
 	if enabled {
-		t.Yes += num
+		atomic.AddInt64(&c.yes, int64(num))
 	} else {
-		t.No += num
+		atomic.AddInt64(&c.no, int64(num))
 	}
-	m.bucket.Toggles[name] = t
 }
 
 func (m *metrics) count(name string, enabled bool) {
@@ -299,7 +392,14 @@ func (m *metrics) count(name string, enabled bool) {
 		return
 	}
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	// best effort delivery, if the channel is full, we skip notifying
+	// means under high load we lose some fidelity here, but we avoid blocking
+	// the main path. That's probably the correct trade-off. Impression data
+	// is the correct insight into this behaviour anyway
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
+	}
 }
 
 func (m *metrics) countVariants(name string, enabled bool, variantName string) {
@@ -308,31 +408,20 @@ func (m *metrics) countVariants(name string, enabled bool, variantName string) {
 	}
 
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
-
-	m.bucketMu.Lock()
-	defer m.bucketMu.Unlock()
-
-	t := m.bucket.Toggles[name]
-	if len(t.Variants) == 0 {
-		t.Variants = make(map[string]int32)
+	// again best effort delivery
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
 	}
 
-	if _, ok := t.Variants[variantName]; !ok {
-		t.Variants[variantName] = 1
-	} else {
-		t.Variants[variantName] += 1
-	}
-	m.bucket.Toggles[name] = t
-}
+	c := m.getOrCreateCounter(name)
 
-func (m *metrics) resetBucket() api.Bucket {
-	prev := m.bucket
-	m.bucket = api.Bucket{
-		Start:   time.Now(),
-		Toggles: map[string]api.ToggleCount{},
+	c.mu.Lock()
+	if c.variants == nil {
+		c.variants = make(map[string]int64)
 	}
-	return prev
+	c.variants[variantName]++
+	c.mu.Unlock()
 }
 
 func (m *metrics) getClientData() ClientData {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,3 +1,6 @@
+//go:build norace
+// +build norace
+
 package unleash
 
 import (
@@ -86,7 +89,9 @@ func TestMetrics_VariantsCountToggles(t *testing.T) {
 	client.WaitForReady()
 	client.GetVariant("foo")
 
-	assert.EqualValues(client.metrics.bucket.Toggles["foo"].No, 1)
+	registered_metric, ok := client.metrics.counters.Load("foo")
+	assert.True(ok, "should have a count for 'foo'")
+	assert.EqualValues(registered_metric.(*toggleCounters).no, 1)
 	client.Close()
 
 	assert.Nil(err, "client should not return an error")
@@ -335,8 +340,13 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	client.WaitForReady()
 	client.IsEnabled("child")
 
-	assert.EqualValues(client.metrics.bucket.Toggles["child"].Yes, 1)
-	assert.EqualValues(client.metrics.bucket.Toggles["parent"].Yes, 0)
+	child_metric, ok := client.metrics.counters.Load("child")
+	assert.True(ok, "should have a count for 'child'")
+	assert.EqualValues(child_metric.(*toggleCounters).yes, 1)
+
+	_, ok = client.metrics.counters.Load("parent")
+	assert.False(ok, "should not have a count for parent'")
+
 	err = client.Close()
 
 	assert.Nil(err, "client should not return an error")
@@ -591,4 +601,37 @@ func TestMetrics_metricsData_includes_new_metadata(t *testing.T) {
 	assert.Nil(err, "Client should close without errors")
 
 	st.Expect(t, gock.IsDone(), true)
+}
+
+func TestReinsertingBucketsAlsoRestoresVariants(t *testing.T) {
+	metrics_handler := &metrics{
+		metricsChannels: metricsChannels{
+			count: make(chan metric, 100),
+		},
+	}
+
+	metrics_handler.countVariants("some-feature", true, "some-variant")
+	registered_metric, ok := metrics_handler.counters.Load("some-feature")
+
+	if !ok {
+		t.Fatal("should have a count for 'some-feature'")
+	}
+
+	assert.EqualValues(t, 1, registered_metric.(*toggleCounters).variants["some-variant"])
+
+	retrieved_bucket, ok := metrics_handler.buildBucketAndReset(time.Now())
+	if !ok {
+		t.Fatal("Missing bucket for 'some-feature'")
+	}
+
+	assert.EqualValues(t, 1, retrieved_bucket.Toggles["some-feature"].Variants["some-variant"])
+
+	metrics_handler.reinsertBucket(retrieved_bucket)
+
+	registered_metric, ok = metrics_handler.counters.Load("some-feature")
+	if !ok {
+		t.Fatal("should have a count for 'some-feature'")
+	}
+
+	assert.EqualValues(t, 1, registered_metric.(*toggleCounters).variants["some-variant"])
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -126,6 +126,7 @@ func TestRepository_OnUpdateCalledWhenFeaturesChangeOnly(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 		WithRefreshInterval(time.Millisecond),
+		WithDisableMetrics(true),
 	)
 	assert.Nil(err, "client should not return an error")
 


### PR DESCRIPTION
Instead of blocking on a single shared Mutex, randomness now uses a sync pool, which gives multiple goroutines a bit more breathing room to get access to randomness without lining up one behind another