### PR TITLE
chore: make metric count channels best effort send

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -59,7 +59,7 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -103,7 +103,7 @@ func TestClient_WithResolver(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -335,7 +335,7 @@ func TestClientWithVariantContext(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -424,7 +424,7 @@ func TestClient_WithSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -502,7 +502,7 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, false).Return()
+	mockListener.On("OnCount", feature, false).Maybe()
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
 	client, err := NewClient(
@@ -606,7 +606,7 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -721,7 +721,7 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -839,7 +839,7 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError").Return()
 
@@ -942,7 +942,7 @@ func TestClient_ShouldFavorStrategyVariantOverFeatureVariant(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1042,7 +1042,7 @@ func TestClient_ShouldReturnOldVariantForNonMatchingStrategyVariant(t *testing.T
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1106,7 +1106,7 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(

--- a/impression_test.go
+++ b/impression_test.go
@@ -58,7 +58,7 @@ func TestImpression_Off(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.Anything).Maybe()
 
 	client := setupClient(t, mockListener)
@@ -107,7 +107,7 @@ func TestImpression_IsEnabled(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -178,7 +178,7 @@ func TestImpression_GetVariant(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -247,7 +247,7 @@ func TestImpression_WithContext(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	userCtx := context.Context{
 		UserId:    ctxUserId,
@@ -411,7 +411,7 @@ func TestImpression_GetChannelMethod(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.AnythingOfType("ImpressionEvent")).Maybe()
 	mockListener.On("OnError", mock.Anything).Maybe()
 

--- a/metrics.go
+++ b/metrics.go
@@ -394,7 +394,14 @@ func (m *metrics) count(name string, enabled bool) {
 		return
 	}
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	// best effort delivery, if the channel is full, we skip notifying
+	// means under high load we lose some fidelity here, but we avoid blocking
+	// the main path. That's probably the correct trade-off. Impression data
+	// is the correct insight into this behaviour anyway
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
+	}
 }
 
 func (m *metrics) countVariants(name string, enabled bool, variantName string) {
@@ -403,7 +410,11 @@ func (m *metrics) countVariants(name string, enabled bool, variantName string) {
 	}
 
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	// again best effort delivery
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
+	}
 
 	c := m.getOrCreateCounter(name)
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,3 +1,6 @@
+//go:build norace
+// +build norace
+
 package unleash
 
 import (

--- a/repository_test.go
+++ b/repository_test.go
@@ -126,6 +126,7 @@ func TestRepository_OnUpdateCalledWhenFeaturesChangeOnly(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 		WithRefreshInterval(time.Millisecond),
+		WithDisableMetrics(true),
 	)
 	assert.Nil(err, "client should not return an error")
 


### PR DESCRIPTION
Last major piece of the performance puzzle. This means feature evaluation events will get dropped under high load, but that's appropriate for an eventing system anyway