### PR TITLE
fix: variant strategies inherit stickiness

### DIFF
--- a/api/feature.go
+++ b/api/feature.go
@@ -86,12 +86,12 @@ func (fr FeatureResponse) SegmentsMap() map[int][]Constraint {
 }
 
 // Get variant for a given feature which is considered as enabled
-func (vc VariantCollection) GetVariant(ctx *context.Context) *Variant {
+func (vc VariantCollection) GetVariant(ctx *context.Context, stickinessOverride *string) *Variant {
 	if len(vc.Variants) > 0 {
 		v := vc.getOverrideVariant(ctx)
 		var variant *Variant
 		if v == nil {
-			variant = vc.getVariantFromWeights(ctx)
+			variant = vc.getVariantFromWeights(ctx, stickinessOverride)
 		} else {
 			variant = &v.Variant
 		}
@@ -102,7 +102,7 @@ func (vc VariantCollection) GetVariant(ctx *context.Context) *Variant {
 	return DISABLED_VARIANT
 }
 
-func (vc VariantCollection) getVariantFromWeights(ctx *context.Context) *Variant {
+func (vc VariantCollection) getVariantFromWeights(ctx *context.Context, stickinessOverride *string) *Variant {
 	totalWeight := 0
 	for _, variant := range vc.Variants {
 		totalWeight += variant.Weight
@@ -110,7 +110,11 @@ func (vc VariantCollection) getVariantFromWeights(ctx *context.Context) *Variant
 	if totalWeight == 0 {
 		return DISABLED_VARIANT
 	}
+
 	stickiness := vc.Variants[0].Stickiness
+	if stickinessOverride != nil {
+		stickiness = *stickinessOverride
+	}
 
 	target := strategies.NormalizedVariantValue(getSeed(ctx, stickiness), vc.GroupId, totalWeight, strategies.VariantNormalizationSeed)
 	counter := uint32(0)

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -132,7 +132,7 @@ func (suite *VariantTestSuite) TestGetVariantWhenFeatureHasNoVariant() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 
 	suite.Equal(DISABLED_VARIANT, variantSetup, "Should return default variant")
 }
@@ -155,7 +155,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnUserId() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarA", variantSetup.Name, "Should return VarA")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -178,7 +178,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnRemoteAddress() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarB", variantSetup.Name, "Should return VarB")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -202,7 +202,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnSessionId() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarA", variantSetup.Name, "Should return VarA")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -226,7 +226,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnCustomProperties() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarC", variantSetup.Name, "Should return VarC")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -244,7 +244,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarD() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -261,7 +261,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarE() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarF", variantSetup.Name, "Should return VarF")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -278,7 +278,7 @@ func (suite *VariantTestSuite) TestGetVariant_ShouldReturnVarF() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarE", variantSetup.Name, "Should return VarE")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 }
@@ -304,7 +304,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnAppName() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")
@@ -326,7 +326,7 @@ func (suite *VariantTestSuite) TestGetVariant_OverrideOnEnvironment() {
 	variantSetup := VariantCollection{
 		GroupId:  mockFeature.Name,
 		Variants: mockFeature.Variants,
-	}.GetVariant(mockContext)
+	}.GetVariant(mockContext, nil)
 	suite.Equal("VarG", variantSetup.Name, "Should return VarG")
 	suite.Equal(true, variantSetup.Enabled, "Should be equal")
 	suite.Equal(expectedPayload, variantSetup.Payload, "Should be equal")

--- a/client.go
+++ b/client.go
@@ -431,7 +431,7 @@ func (uc *Client) getVariantWithoutMetrics(feature string, snapshot *FeatureMemo
 	return api.VariantCollection{
 		GroupId:  f.Name,
 		Variants: f.Variants,
-	}.GetVariant(ctx)
+	}.GetVariant(ctx, nil)
 }
 
 // Close stops the client from syncing data from the server.

--- a/client_test.go
+++ b/client_test.go
@@ -59,7 +59,7 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -103,7 +103,7 @@ func TestClient_WithResolver(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -335,7 +335,7 @@ func TestClientWithVariantContext(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -424,7 +424,7 @@ func TestClient_WithSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -502,7 +502,7 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, false).Return()
+	mockListener.On("OnCount", feature, false).Maybe()
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
 	client, err := NewClient(
@@ -606,7 +606,7 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -721,7 +721,7 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(
@@ -839,7 +839,7 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError").Return()
 
@@ -942,7 +942,7 @@ func TestClient_ShouldFavorStrategyVariantOverFeatureVariant(t *testing.T) {
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1042,7 +1042,7 @@ func TestClient_ShouldReturnOldVariantForNonMatchingStrategyVariant(t *testing.T
 
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
-	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Return()
+	mockListener.On("OnCount", mock.AnythingOfType("string"), mock.AnythingOfType("bool")).Maybe()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
 	mockListener.On("OnError", mock.AnythingOfType("*errors.errorString"))
 
@@ -1106,7 +1106,7 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnError").Return()
 
 	client, err := NewClient(

--- a/feature_state.go
+++ b/feature_state.go
@@ -81,12 +81,20 @@ func (s *FeatureMemoryState) evaluateFeature(
 				}, fmt.Errorf("invalid groupId type for feature %s", f.Name)
 			}
 
+			var stickiness *string
+
+			if v, ok := stCfg.Parameters[strategy.ParamStickiness]; ok {
+				if s, ok := v.(string); ok {
+					stickiness = &s
+				}
+			}
+
 			return api.StrategyResult{
 				Enabled: true,
 				Variant: api.VariantCollection{
 					GroupId:  groupId,
 					Variants: stCfg.Variants,
-				}.GetVariant(ctx),
+				}.GetVariant(ctx, stickiness),
 			}, nil
 		}
 

--- a/impression_test.go
+++ b/impression_test.go
@@ -58,7 +58,7 @@ func TestImpression_Off(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.Anything).Maybe()
 
 	client := setupClient(t, mockListener)
@@ -107,7 +107,7 @@ func TestImpression_IsEnabled(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -178,7 +178,7 @@ func TestImpression_GetVariant(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	mockListener.On("OnImpression", mock.MatchedBy(func(e ImpressionEvent) bool {
 		return e.FeatureName == feature &&
@@ -247,7 +247,7 @@ func TestImpression_WithContext(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 
 	userCtx := context.Context{
 		UserId:    ctxUserId,
@@ -411,7 +411,7 @@ func TestImpression_GetChannelMethod(t *testing.T) {
 	mockListener := &MockedListener{}
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", feature, true).Return()
+	mockListener.On("OnCount", feature, true).Maybe()
 	mockListener.On("OnImpression", mock.AnythingOfType("ImpressionEvent")).Maybe()
 	mockListener.On("OnError", mock.Anything).Maybe()
 

--- a/metrics.go
+++ b/metrics.go
@@ -394,7 +394,14 @@ func (m *metrics) count(name string, enabled bool) {
 		return
 	}
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	// best effort delivery, if the channel is full, we skip notifying
+	// means under high load we lose some fidelity here, but we avoid blocking
+	// the main path. That's probably the correct trade-off. Impression data
+	// is the correct insight into this behaviour anyway
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
+	}
 }
 
 func (m *metrics) countVariants(name string, enabled bool, variantName string) {
@@ -403,7 +410,11 @@ func (m *metrics) countVariants(name string, enabled bool, variantName string) {
 	}
 
 	m.add(name, enabled, 1)
-	m.metricsChannels.count <- metric{Name: name, Enabled: enabled}
+	// again best effort delivery
+	select {
+	case m.metricsChannels.count <- metric{Name: name, Enabled: enabled}:
+	default:
+	}
 
 	c := m.getOrCreateCounter(name)
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,3 +1,6 @@
+//go:build norace
+// +build norace
+
 package unleash
 
 import (

--- a/repository_test.go
+++ b/repository_test.go
@@ -126,6 +126,7 @@ func TestRepository_OnUpdateCalledWhenFeaturesChangeOnly(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 		WithRefreshInterval(time.Millisecond),
+		WithDisableMetrics(true),
 	)
 	assert.Nil(err, "client should not return an error")
 


### PR DESCRIPTION
Fixes a bug in the variant strategy implementation. This fails the client spec tests roughly half the time so no idea why it hasn't been fixed yet. Can't fix this on v5 because it requires a change to a public API. This API should not be public but it is