### PR TITLE
chore: bump go.mod to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-[![Build Status](https://github.com/Unleash/unleash-go-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/Unleash/unleash-go-sdk/actions/workflows/build.yml) [![GoDoc](https://pkg.go.dev/badge/github.com/Unleash/unleash-go-sdk/v5?status.svg)](https://pkg.go.dev/github.com/Unleash/unleash-go-sdk/v5) [![Go Report Card](https://goreportcard.com/badge/github.com/Unleash/unleash-go-sdk/v5)](https://goreportcard.com/report/github.com/Unleash/unleash-go-sdk/v5)
-[![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-go-sdk/badge.svg?branch=v5)](https://coveralls.io/github/Unleash/unleash-go-sdk?branch=v5)
+[![Build Status](https://github.com/Unleash/unleash-go-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/Unleash/unleash-go-sdk/actions/workflows/build.yml) [![GoDoc](https://pkg.go.dev/badge/github.com/Unleash/unleash-go-sdk/v6?status.svg)](https://pkg.go.dev/github.com/Unleash/unleash-go-sdk/v6) [![Go Report Card](https://goreportcard.com/badge/github.com/Unleash/unleash-go-sdk/v6)](https://goreportcard.com/report/github.com/Unleash/unleash-go-sdk/v6)
+[![Coverage Status](https://coveralls.io/repos/github/Unleash/unleash-go-sdk/badge.svg?branch=v6)](https://coveralls.io/github/Unleash/unleash-go-sdk?branch=v6)
 
 # unleash-go-sdk
 
 Unleash Client for Go. Read more about the [Unleash project](https://github.com/Unleash/unleash)
 
-**Version 5 of the client changed the module name from `github.com/Unleash/unleash-client-go/v4` to `github.com/Unleash/unleash-go-sdk/v5`. Other than the module name change, it should be a drop-in replacement for the previous version.** If you're using the v4 branch, consider migrating to v5 as soon as possible.
+**Version 6 of the client changed the module name from `github.com/Unleash/unleash-client-go/v5` to `github.com/Unleash/unleash-go-sdk/v6`. Other than the module name change, it should be a drop-in replacement for the previous version.** If you're using the v5 branch, consider migrating to v6 as soon as possible.
 
 Unleash is a private, secure, and scalable [feature management platform](https://www.getunleash.io/) built to reduce the risk of releasing new features and accelerate software development. This Backend Go SDK is designed to help you integrate with Unleash and evaluate feature flags inside your application.
 
@@ -25,7 +25,7 @@ The client may work on older versions of Go as well, but is not actively tested.
 To install the latest version of the client use:
 
 ```bash
-go get github.com/Unleash/unleash-go-sdk/v5
+go get github.com/Unleash/unleash-go-sdk/v6
 ```
 
 ### 2. Initialize unleash
@@ -35,7 +35,7 @@ The easiest way to get started with Unleash is to initialize it early in your ap
 **Asynchronous initialization example:**
 ```go
 import (
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 )
 
 func init() {
@@ -52,7 +52,7 @@ func init() {
 
 ```go
 import (
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 )
 
 func init() {
@@ -78,7 +78,7 @@ Bootstrapping from file on disk is then done using something similar to:
 
 ```go
 import (
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 )
 
 func init() {
@@ -99,7 +99,7 @@ Bootstrapping from S3 is then done by downloading the file using the AWS library
 
 ```go
 import (
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -143,7 +143,7 @@ Since the Google Cloud Storage API returns a Reader, implementing a Bootstrap fr
 
 ```go
 import (
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 	"cloud.google.com/go/storage"
 )
 
@@ -218,7 +218,7 @@ unleash.IsEnabled("someToggle", unleash.WithContext(ctx))
 
 ### Caveat
 
-This client uses go routines to report several events and doesn't drain the channel by default. So you need to either register a listener using `WithListener` or drain the channel "manually" (demonstrated in [this example](https://github.com/Unleash/unleash-go-sdk/blob/v5/example_with_instance_test.go)).
+This client uses go routines to report several events and doesn't drain the channel by default. So you need to either register a listener using `WithListener` or drain the channel "manually" (demonstrated in [this example](https://github.com/Unleash/unleash-go-sdk/blob/v6/example_with_instance_test.go)).
 
 ### Feature Resolver
 
@@ -293,7 +293,7 @@ To override dependency on unleash-go-sdk github repository to a local developmen
 you can add the following to your apps `go.mod`:
 
 ```mod
-    replace github.com/Unleash/unleash-go-sdk/v5 => ../unleash-go-sdk/
+    replace github.com/Unleash/unleash-go-sdk/v6 => ../unleash-go-sdk/
 ```
 
 
@@ -355,11 +355,11 @@ Here's an example of how the output could look like:
 ```
 goos: darwin
 goarch: arm64
-pkg: github.com/Unleash/unleash-go-sdk/v5
+pkg: github.com/Unleash/unleash-go-sdk/v6
 BenchmarkFeatureToggleEvaluation-8 Final Estimated Operations Per Day: 101.131 billion (1.011315e+11)
 13635154 854.3 ns/op
 PASS
-ok github.com/Unleash/unleash-go-sdk/v5 13.388s
+ok github.com/Unleash/unleash-go-sdk/v6 13.388s
 ```
 
 In this example the benchmark was run on a MacBook Pro (M1 Pro, 2021) with 16GB RAM.

--- a/api/feature.go
+++ b/api/feature.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/internal/strategies"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/internal/strategies"
 )
 
 type ParameterMap map[string]any

--- a/api/variant.go
+++ b/api/variant.go
@@ -2,7 +2,7 @@ package api
 
 import "slices"
 
-import "github.com/Unleash/unleash-go-sdk/v5/context"
+import "github.com/Unleash/unleash-go-sdk/v6/context"
 
 var DISABLED_VARIANT = &Variant{
 	Name:           "disabled",

--- a/api/variant_test.go
+++ b/api/variant_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 type mockStorage map[string]api.Feature

--- a/bootstrap_storage.go
+++ b/bootstrap_storage.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 type BootstrapStorage struct {

--- a/client.go
+++ b/client.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	s "github.com/Unleash/unleash-go-sdk/v5/internal/strategies"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	s "github.com/Unleash/unleash-go-sdk/v6/internal/strategies"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 const (

--- a/client_test.go
+++ b/client_test.go
@@ -3,8 +3,8 @@ package unleash
 import (
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 

--- a/config.go
+++ b/config.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type configOption struct {

--- a/delta_processor.go
+++ b/delta_processor.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 type deltaProcessor struct {

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 )

--- a/example_custom_strategy_test.go
+++ b/example_custom_strategy_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 type ActiveForUserWithEmailStrategy struct{}

--- a/example_fallback_func_test.go
+++ b/example_fallback_func_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 const MissingFeature = "does_not_exist"

--- a/example_simple_usage_test.go
+++ b/example_simple_usage_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 )
 
 const PropertyName = "eid.enabled"

--- a/example_with_instance_test.go
+++ b/example_with_instance_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 )
 
 // Sync runs the client event loop. All of the channels must be read to avoid blocking the

--- a/feature_state.go
+++ b/feature_state.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/internal/constraints"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/internal/constraints"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type FeatureMemoryState struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Unleash/unleash-go-sdk/v5
+module github.com/Unleash/unleash-go-sdk/v6
 
 go 1.23
 

--- a/impression.go
+++ b/impression.go
@@ -1,7 +1,7 @@
 package unleash
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 type EventType string

--- a/impression_test.go
+++ b/impression_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/internal/api/event.go
+++ b/internal/api/event.go
@@ -3,7 +3,7 @@ package api
 import (
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 type EventResponse struct {

--- a/internal/constraints/check.go
+++ b/internal/constraints/check.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"fmt"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 // Check checks if all the constraints are fulfilled by the context.

--- a/internal/constraints/check_test.go
+++ b/internal/constraints/check_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/constraints/operator_date.go
+++ b/internal/constraints/operator_date.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 func operatorDateBefore(ctx *context.Context, constraint api.Constraint) (bool, error) {

--- a/internal/constraints/operator_date_test.go
+++ b/internal/constraints/operator_date_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/constraints/operator_in.go
+++ b/internal/constraints/operator_in.go
@@ -1,8 +1,8 @@
 package constraints
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"slices"
 )
 

--- a/internal/constraints/operator_in_test.go
+++ b/internal/constraints/operator_in_test.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/constraints/operator_num.go
+++ b/internal/constraints/operator_num.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"math/big"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 func operatorNumEq(ctx *context.Context, constraint api.Constraint) (bool, error) {

--- a/internal/constraints/operator_num_test.go
+++ b/internal/constraints/operator_num_test.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/constraints/operator_semver.go
+++ b/internal/constraints/operator_semver.go
@@ -2,8 +2,8 @@ package constraints
 
 import (
 	"github.com/Masterminds/semver/v3"
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 func operatorSemverEq(ctx *context.Context, constraint api.Constraint) (bool, error) {

--- a/internal/constraints/operator_semver_test.go
+++ b/internal/constraints/operator_semver_test.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/constraints/operator_str.go
+++ b/internal/constraints/operator_str.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"strings"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 )
 
 func operatorStrContains(ctx *context.Context, constraint api.Constraint) bool {

--- a/internal/constraints/operator_str_test.go
+++ b/internal/constraints/operator_str_test.go
@@ -3,8 +3,8 @@ package constraints
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/application_hostname.go
+++ b/internal/strategies/application_hostname.go
@@ -3,8 +3,8 @@ package strategies
 import (
 	"strings"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type applicationHostnameStrategy struct {

--- a/internal/strategies/application_hostname_test.go
+++ b/internal/strategies/application_hostname_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/default.go
+++ b/internal/strategies/default.go
@@ -1,6 +1,6 @@
 package strategies
 
-import "github.com/Unleash/unleash-go-sdk/v5/context"
+import "github.com/Unleash/unleash-go-sdk/v6/context"
 
 type defaultStrategy struct{}
 

--- a/internal/strategies/flexible_rollout.go
+++ b/internal/strategies/flexible_rollout.go
@@ -1,8 +1,8 @@
 package strategies
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type stickiness string

--- a/internal/strategies/flexible_rollout_test.go
+++ b/internal/strategies/flexible_rollout_test.go
@@ -7,8 +7,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/gradual_rollout_random.go
+++ b/internal/strategies/gradual_rollout_random.go
@@ -1,8 +1,8 @@
 package strategies
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type gradualRolloutRandomStrategy struct {

--- a/internal/strategies/gradual_rollout_random_test.go
+++ b/internal/strategies/gradual_rollout_random_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/gradual_rollout_session_id.go
+++ b/internal/strategies/gradual_rollout_session_id.go
@@ -1,8 +1,8 @@
 package strategies
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type gradualRolloutSessionId struct {

--- a/internal/strategies/gradual_rollout_session_id_test.go
+++ b/internal/strategies/gradual_rollout_session_id_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/gradual_rollout_user_id.go
+++ b/internal/strategies/gradual_rollout_user_id.go
@@ -1,8 +1,8 @@
 package strategies
 
 import (
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type gradualRolloutUserId struct {

--- a/internal/strategies/gradual_rollout_user_id_test.go
+++ b/internal/strategies/gradual_rollout_user_id_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/remote_address_test.go
+++ b/internal/strategies/remote_address_test.go
@@ -3,8 +3,8 @@ package strategies
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/strategies/remote_addresss.go
+++ b/internal/strategies/remote_addresss.go
@@ -4,8 +4,8 @@ import (
 	"net"
 	"strings"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type remoteAddressStrategy struct {

--- a/internal/strategies/user_with_id.go
+++ b/internal/strategies/user_with_id.go
@@ -3,8 +3,8 @@ package strategies
 import (
 	"strings"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 )
 
 type userWithIdStrategy struct{}

--- a/internal/strategies/user_with_id_test.go
+++ b/internal/strategies/user_with_id_test.go
@@ -3,8 +3,8 @@ package strategies
 import (
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/Unleash/unleash-go-sdk/v5/strategy"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/Unleash/unleash-go-sdk/v6/strategy"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/metrics.go
+++ b/metrics.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/internal/api"
+	"github.com/Unleash/unleash-go-sdk/v6/internal/api"
 )
 
 // MetricsData represents the data sent to the unleash server.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -17,8 +17,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	internalapi "github.com/Unleash/unleash-go-sdk/v5/internal/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	internalapi "github.com/Unleash/unleash-go-sdk/v6/internal/api"
 	"github.com/h2non/gock"
 	"github.com/nbio/st"
 	"github.com/stretchr/testify/assert"

--- a/repository.go
+++ b/repository.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 var SEGMENT_CLIENT_SPEC_VERSION = "4.3.1"

--- a/repository_test.go
+++ b/repository_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/h2non/gock"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )

--- a/spec_test.go
+++ b/spec_test.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
-	"github.com/Unleash/unleash-go-sdk/v5/context"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"

--- a/storage.go
+++ b/storage.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
 
 // Storage controls persistence of the SDK state (features + segments).

--- a/strategy/strategy.go
+++ b/strategy/strategy.go
@@ -1,6 +1,6 @@
 package strategy
 
-import "github.com/Unleash/unleash-go-sdk/v5/context"
+import "github.com/Unleash/unleash-go-sdk/v6/context"
 
 const (
 	// ParamHostNames is a parameter indicating a comma separated list of hostnames.

--- a/streaming_client.go
+++ b/streaming_client.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 	"github.com/launchdarkly/eventsource"
 )
 

--- a/streaming_client_test.go
+++ b/streaming_client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/streaming_delta_integration_test.go
+++ b/streaming_delta_integration_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/Unleash/unleash-go-sdk/v5/api"
+	"github.com/Unleash/unleash-go-sdk/v6/api"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/unleash.go
+++ b/unleash.go
@@ -1,6 +1,6 @@
 package unleash
 
-import "github.com/Unleash/unleash-go-sdk/v5/api"
+import "github.com/Unleash/unleash-go-sdk/v6/api"
 
 var defaultClient *Client
 

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Unleash/unleash-go-sdk/v5"
+	"github.com/Unleash/unleash-go-sdk/v6"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This bumps the version in go.mod to v6 along with all references to v5