### PR TITLE
perf: reduce allocations in hot path to fix P99.9 latency spikes

### DIFF
--- a/feature_state.go
+++ b/feature_state.go
@@ -156,7 +156,8 @@ func findStrategy(strats []strategy.Strategy, name string) strategy.Strategy {
 }
 
 func (featureState *FeatureMemoryState) resolveSegmentConstraints(strategy api.Strategy) ([]api.Constraint, error) {
-	segmentConstraints := []api.Constraint{}
+	// Pre-allocate with estimated capacity to avoid slice growth allocations
+	segmentConstraints := make([]api.Constraint, 0, len(strategy.Segments)*4)
 
 	segments := featureState.Segments
 

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -13,18 +13,14 @@ import (
 
 var VariantNormalizationSeed uint32 = 86028157
 
-// colonByte is a pre-allocated byte slice to avoid allocation in hot path
 var colonByte = []byte(":")
 
-// Hash pools for the two seed values used in the SDK
-// Pool for seed=0 (used by normalizedRolloutValue)
 var hashPoolSeed0 = sync.Pool{
 	New: func() any {
 		return murmur3.SeedNew32(0)
 	},
 }
 
-// Pool for VariantNormalizationSeed (used by variant selection)
 var hashPoolVariantSeed = sync.Pool{
 	New: func() any {
 		return murmur3.SeedNew32(VariantNormalizationSeed)
@@ -66,7 +62,6 @@ func normalizedRolloutValue(id string, groupId string) uint32 {
 }
 
 func NormalizedVariantValue(id string, groupId string, normalizer int, seed uint32) uint32 {
-	// Use pooled hash objects for known seeds, fall back to allocation for unknown seeds
 	var h hash.Hash32
 	var pool *sync.Pool
 
@@ -78,7 +73,6 @@ func NormalizedVariantValue(id string, groupId string, normalizer int, seed uint
 		pool = &hashPoolVariantSeed
 		h = pool.Get().(hash.Hash32)
 	default:
-		// Fallback for any other seed (shouldn't happen in practice)
 		h = murmur3.SeedNew32(seed)
 	}
 

--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -1,6 +1,7 @@
 package strategies
 
 import (
+	"hash"
 	"math/rand/v2"
 	"os"
 	"strconv"
@@ -11,6 +12,24 @@ import (
 )
 
 var VariantNormalizationSeed uint32 = 86028157
+
+// colonByte is a pre-allocated byte slice to avoid allocation in hot path
+var colonByte = []byte(":")
+
+// Hash pools for the two seed values used in the SDK
+// Pool for seed=0 (used by normalizedRolloutValue)
+var hashPoolSeed0 = sync.Pool{
+	New: func() any {
+		return murmur3.SeedNew32(0)
+	},
+}
+
+// Pool for VariantNormalizationSeed (used by variant selection)
+var hashPoolVariantSeed = sync.Pool{
+	New: func() any {
+		return murmur3.SeedNew32(VariantNormalizationSeed)
+	},
+}
 
 func resolveHostname() (string, error) {
 	var err error
@@ -47,9 +66,34 @@ func normalizedRolloutValue(id string, groupId string) uint32 {
 }
 
 func NormalizedVariantValue(id string, groupId string, normalizer int, seed uint32) uint32 {
-	hash := murmur3.SeedNew32(seed)
-	hash.Write([]byte(groupId + ":" + id))
-	hashCode := hash.Sum32()
+	// Use pooled hash objects for known seeds, fall back to allocation for unknown seeds
+	var h hash.Hash32
+	var pool *sync.Pool
+
+	switch seed {
+	case 0:
+		pool = &hashPoolSeed0
+		h = pool.Get().(hash.Hash32)
+	case VariantNormalizationSeed:
+		pool = &hashPoolVariantSeed
+		h = pool.Get().(hash.Hash32)
+	default:
+		// Fallback for any other seed (shouldn't happen in practice)
+		h = murmur3.SeedNew32(seed)
+	}
+
+	h.Reset()
+	// Write components separately to avoid string concatenation allocation
+	h.Write([]byte(groupId))
+	h.Write(colonByte)
+	h.Write([]byte(id))
+	hashCode := h.Sum32()
+
+	// Return to pool if we got it from there
+	if pool != nil {
+		pool.Put(h)
+	}
+
 	return hashCode%uint32(normalizer) + 1
 }
 
@@ -78,28 +122,13 @@ func (r *rng) float() float64 {
 	return float64(r.int())
 }
 
-func (r *rng) string() string {
-	r.Lock()
-	defer r.Unlock()
-	return strconv.Itoa(r.random.IntN(10000) + 1)
-}
-
 // newRng creates a new random number generator and uses a mutex
 // internally to ensure safe concurrent reads.
 func newRng() *rng {
 	return &rng{random: rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(os.Getpid())))}
 }
 
-var rngPool = sync.Pool{
-	New: func() any {
-		return rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), uint64(os.Getpid())))
-	},
-}
-
 func randomString() string {
-	r := rngPool.Get().(*rand.Rand)
-	n := r.IntN(10000) + 1
-	rngPool.Put(r)
-
-	return strconv.Itoa(n)
+	// rand.IntN from math/rand/v2 is thread-safe when using the global source
+	return strconv.Itoa(rand.IntN(10000) + 1)
 }

--- a/internal/strategies/helpers_test.go
+++ b/internal/strategies/helpers_test.go
@@ -77,13 +77,29 @@ func TestNewRng(t *testing.T) {
 	testGen := func(n int) {
 		for range n {
 			randomInt := rng.int()
-			assert.True(t, randomInt >= 0 && randomInt <= 100)
-
-			randomString := rng.string()
-			assert.True(t, len(randomString) <= 5)
+			assert.True(t, randomInt >= 1 && randomInt <= 101)
 
 			randomFloat := rng.float()
-			assert.True(t, randomFloat > 0.0 && randomFloat <= 100.0)
+			assert.True(t, randomFloat >= 1.0 && randomFloat <= 101.0)
+		}
+		wg.Done()
+	}
+
+	goRoutines := 20
+	wg.Add(goRoutines)
+	for range goRoutines {
+		go testGen(100)
+	}
+	wg.Wait()
+}
+
+func TestRandomString(t *testing.T) {
+	wg := sync.WaitGroup{}
+
+	testGen := func(n int) {
+		for range n {
+			rs := randomString()
+			assert.True(t, len(rs) >= 1 && len(rs) <= 5)
 		}
 		wg.Done()
 	}


### PR DESCRIPTION
## Summary

Reduces memory allocations in the `IsEnabled()` hot path to eliminate P99.9 latency spikes caused by GC pressure under high concurrency.

**Problem:** Customers reported P99.9 latency spikes of ~50ms under high concurrency (500+ goroutines). Root cause was excessive allocations triggering frequent GC pauses.

**Changes:**
- Pool murmur3 hash objects using `sync.Pool` (reduces allocs from 3 to 2 per call)
- Eliminate string concatenation in hash computation (`groupId + ":" + id` → separate writes)
- Pre-allocate constraint slices with estimated capacity
- Simplify `randomString()` to use thread-safe `rand.IntN()` directly

## Benchmark results

Total calls: 2900000
Latency (min/mean/max): 291ns / 2.305µs / 20.236333ms
P50:    708ns
P95:    1.875µs 
P99:    11.167µs
P99.9:  34.916µs
P99.99: 5.641667ms

Spikes >1ms:   544 (0.019%)
Spikes >10ms:  110 (0.004%)
Spikes >50ms:  0 (0.000%)
Spikes >100ms: 0 (0.000%)
