### PR TITLE
fix(client): don't block IsEnabled() return while recording metrics

### DIFF
--- a/client.go
+++ b/client.go
@@ -286,7 +286,7 @@ func (uc *Client) IsEnabled(feature string, options ...FeatureOption) (enabled b
 	result, f := uc.isEnabled(feature, options...)
 	enabled = result.Enabled
 
-	defer func() {
+	go func() {
 		uc.metrics.count(feature, enabled)
 
 		if f != nil && f.ImpressionData && uc.impressionListener != nil {

--- a/client.go
+++ b/client.go
@@ -445,7 +445,7 @@ func (uc *Client) isParentDependencySatisfied(feature *api.Feature, context cont
 func (uc *Client) GetVariant(feature string, options ...VariantOption) (variant *api.Variant) {
 	variant = uc.getVariantWithoutMetrics(feature, options...)
 
-	defer func() {
+	go func() {
 		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
 
 		f := uc.repository.getToggle(feature)

--- a/client.go
+++ b/client.go
@@ -46,7 +46,6 @@ type Client struct {
 	errorChannels
 	options            configOption
 	repository         *repository
-	counters           sync.WaitGroup
 	metrics            *metrics
 	strategies         []strategy.Strategy
 	errorListener      ErrorListener
@@ -58,6 +57,7 @@ type Client struct {
 	update             chan bool
 	close              chan struct{}
 	closed             chan struct{}
+	counters           sync.WaitGroup
 	count              chan metric
 	sent               chan MetricsData
 	registered         chan ClientData
@@ -287,7 +287,10 @@ func (uc *Client) IsEnabled(feature string, options ...FeatureOption) (enabled b
 	result, f := uc.isEnabled(feature, options...)
 	enabled = result.Enabled
 
+	uc.counters.Add(1)
 	go func() {
+		defer uc.counters.Done()
+
 		uc.metrics.count(feature, enabled)
 
 		if f != nil && f.ImpressionData && uc.impressionListener != nil {
@@ -445,7 +448,10 @@ func (uc *Client) isParentDependencySatisfied(feature *api.Feature, context cont
 func (uc *Client) GetVariant(feature string, options ...VariantOption) (variant *api.Variant) {
 	variant = uc.getVariantWithoutMetrics(feature, options...)
 
+	uc.counters.Add(1)
 	go func() {
+		defer uc.counters.Done()
+
 		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
 
 		f := uc.repository.getToggle(feature)

--- a/client.go
+++ b/client.go
@@ -2,10 +2,10 @@ package unleash
 
 import (
 	"fmt"
-
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v5/api"
@@ -46,6 +46,7 @@ type Client struct {
 	errorChannels
 	options            configOption
 	repository         *repository
+	counters           sync.WaitGroup
 	metrics            *metrics
 	strategies         []strategy.Strategy
 	errorListener      ErrorListener
@@ -529,6 +530,7 @@ func (uc *Client) getVariantWithoutMetrics(feature string, options ...VariantOpt
 // Close stops the client from syncing data from the server.
 func (uc *Client) Close() error {
 	uc.repository.Close()
+	uc.counters.Wait()
 	uc.metrics.Close()
 	if uc.options.listener != nil {
 		// Wait for sync to exit.

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -84,14 +84,17 @@ func TestMetrics_VariantsCountToggles(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithListener(mockListener),
 	)
+	require.NoError(t, err, "client should not return an error")
 
 	client.WaitForReady()
 	client.GetVariant("foo")
 
-	assert.EqualValues(client.metrics.bucket.Toggles["foo"].No, 1)
-	client.Close()
+	// Let the metric recorder goroutine finish writing before we start looking inside the underlying data structure.
+	client.counters.Wait()
 
-	assert.Nil(err, "client should not return an error")
+	assert.EqualValues(client.metrics.bucket.Toggles["foo"].No, 1)
+	_ = client.Close()
+
 	assert.True(gock.IsDone(), "there should be no more mocks")
 }
 
@@ -376,13 +379,7 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnError").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-
-	// We need to know when the count happened to reliably inspect the underlying metrics data structure.
-	// Buffer size 1 to prevent the test from blocking if the metric gets reported before we register the receiver.
-	countReporter := make(chan struct{}, 1)
-	mockListener.On("OnCount", "child", true).Run(func(mock.Arguments) {
-		countReporter <- struct{}{}
-	}).Return()
+	mockListener.On("OnCount", "child", true).Return()
 
 	client, err := NewClient(
 		WithUrl(mockerServer),
@@ -395,9 +392,8 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 
 	client.IsEnabled("child")
 
-	// Let the metric recorder goroutine finish writing
-	// before we start looking inside the underlying data structure.
-	<-countReporter
+	// Let the metric recorder goroutine finish writing before we start looking inside the underlying data structure.
+	client.counters.Wait()
 
 	assert.EqualValues(client.metrics.bucket.Toggles["child"].Yes, 1)
 	assert.EqualValues(client.metrics.bucket.Toggles["parent"].Yes, 0)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -376,7 +376,13 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	mockListener.On("OnReady").Return()
 	mockListener.On("OnError").Return()
 	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
-	mockListener.On("OnCount", "child", true).Return()
+
+	// We need to know when the count happened to reliably inspect the underlying metrics data structure.
+	// Buffer size 1 to prevent the test from blocking if the metric gets reported before we register the receiver.
+	countReporter := make(chan struct{}, 1)
+	mockListener.On("OnCount", "child", true).Run(func(mock.Arguments) {
+		countReporter <- struct{}{}
+	}).Return()
 
 	client, err := NewClient(
 		WithUrl(mockerServer),
@@ -389,9 +395,10 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 
 	client.IsEnabled("child")
 
-	// Give the metric recorder goroutine time to finish writing
-	// before we start looking inside the underlying maps.
-	time.Sleep(10 * time.Millisecond)
+	// Let the metric recorder goroutine finish writing
+	// before we start looking inside the underlying data structure.
+	<-countReporter
+
 	assert.EqualValues(client.metrics.bucket.Toggles["child"].Yes, 1)
 	assert.EqualValues(client.metrics.bucket.Toggles["parent"].Yes, 0)
 	err = client.Close()

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,6 +21,7 @@ import (
 	"github.com/nbio/st"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetrics_RegisterInstance(t *testing.T) {
@@ -264,6 +266,49 @@ func TestMetrics_SendMetricsFail(t *testing.T) {
 
 	// Now OnSent should have been called as /client/metrics returned 200.
 	mockListener.AssertCalled(t, "OnSent", mock.AnythingOfType("MetricsData"))
+}
+
+func BenchmarkMetrics_IsEnabled(b *testing.B) {
+	defer gock.OffAll()
+
+	gock.New(mockerServer).
+		Post("/client/register").
+		Reply(200)
+
+	gock.New(mockerServer).
+		Get("/client/features").
+		Reply(200).
+		JSON(api.FeatureResponse{})
+
+	mockListener := &MockedListener{}
+	mockListener.On("OnReady").Return()
+	mockListener.On("OnRegistered", mock.AnythingOfType("ClientData"))
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithListener(NoopListener{}),
+	)
+	require.NoError(b, err, "client should not return an error")
+	b.Cleanup(func() { _ = client.Close() })
+
+	const thresholdMs = 50
+	var callsOverThreshold int
+
+	var wg sync.WaitGroup
+	for b.Loop() {
+		wg.Go(func() {
+			start := time.Now()
+			client.IsEnabled("foo")
+			if time.Since(start) >= thresholdMs*time.Millisecond {
+				callsOverThreshold++
+			}
+		})
+	}
+	wg.Wait()
+
+	b.Logf("Calls over threshold of %d ms: %d / %d (%.2f %%)", thresholdMs, callsOverThreshold, b.N, float64(callsOverThreshold)/float64(b.N)*100)
 }
 
 func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -294,7 +294,7 @@ func BenchmarkMetrics_IsEnabled(b *testing.B) {
 	b.Cleanup(func() { _ = client.Close() })
 
 	const thresholdMs = 50
-	var callsOverThreshold int
+	var callsOverThreshold atomic.Uint32
 
 	var wg sync.WaitGroup
 	wg.Add(b.N)
@@ -304,7 +304,7 @@ func BenchmarkMetrics_IsEnabled(b *testing.B) {
 			start := time.Now()
 			client.IsEnabled("foo")
 			if time.Since(start) >= thresholdMs*time.Millisecond {
-				callsOverThreshold++
+				callsOverThreshold.Add(1)
 			}
 
 			wg.Done()
@@ -313,7 +313,10 @@ func BenchmarkMetrics_IsEnabled(b *testing.B) {
 	wg.Wait()
 	b.StopTimer()
 
-	b.Logf("Calls over threshold of %d ms: %d / %d (%.2f %%)", thresholdMs, callsOverThreshold, b.N, float64(callsOverThreshold)/float64(b.N)*100)
+	b.Logf(
+		"Calls over threshold of %d ms: %d / %d (%.2f %%)",
+		thresholdMs, callsOverThreshold.Load(), b.N, float64(callsOverThreshold.Load())/float64(b.N)*100,
+	)
 }
 
 func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v5/api"
@@ -298,16 +297,21 @@ func BenchmarkMetrics_IsEnabled(b *testing.B) {
 	var callsOverThreshold int
 
 	var wg sync.WaitGroup
-	for b.Loop() {
-		wg.Go(func() {
+	wg.Add(b.N)
+	b.ResetTimer()
+	for range b.N {
+		go func() {
 			start := time.Now()
 			client.IsEnabled("foo")
 			if time.Since(start) >= thresholdMs*time.Millisecond {
 				callsOverThreshold++
 			}
-		})
+
+			wg.Done()
+		}()
 	}
 	wg.Wait()
+	b.StopTimer()
 
 	b.Logf("Calls over threshold of %d ms: %d / %d (%.2f %%)", thresholdMs, callsOverThreshold, b.N, float64(callsOverThreshold)/float64(b.N)*100)
 }
@@ -380,10 +384,11 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 	client.WaitForReady()
 
-	synctest.Test(t, func(*testing.T) {
-		client.IsEnabled("child")
-	})
+	client.IsEnabled("child")
 
+	// Give the metric recorder goroutine time to finish writing
+	// before we start looking inside the underlying maps.
+	time.Sleep(10 * time.Millisecond)
 	assert.EqualValues(client.metrics.bucket.Toggles["child"].Yes, 1)
 	assert.EqualValues(client.metrics.bucket.Toggles["parent"].Yes, 0)
 	err = client.Close()

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v5/api"
@@ -378,7 +379,10 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	)
 	assert.Nil(err, "client should not return an error")
 	client.WaitForReady()
-	client.IsEnabled("child")
+
+	synctest.Test(t, func(*testing.T) {
+		client.IsEnabled("child")
+	})
 
 	assert.EqualValues(client.metrics.bucket.Toggles["child"].Yes, 1)
 	assert.EqualValues(client.metrics.bucket.Toggles["parent"].Yes, 0)


### PR DESCRIPTION
Hi! :wave:

## About the changes

With metrics enabled, `Client.IsEnabled(…)` and its friend `Client.GetVariant(…)` block until they're done recording the lookup to the internal metrics store. (Not to the metrics server – just the internal map.)

The current `IsEnabled(…)` implementation with the deferred function looks a bit strange to me, and my interpretation is that the metrics stuff was _intended_ to be non-blocking – but alas, that's not how `defer` works.

I had a look at the deferred function, and found what's actually blocking. The `count` metric channel is unbuffered, so sending a message blocks until it's empty. In other words, we rely on the goroutine that consumes its messages to keep up. With a Very High number of concurrent goroutines, it doesn't get scheduled in time to receive each message as they enter the channel, and the channel starts blocking message sending.

Here's the blocking line:

https://github.com/Unleash/unleash-go-sdk/blob/40bd14135f7339a5284a1db75bf6aa387929553b/metrics.go#L302

I added a benchmark that reliably reproduces the issue. It calls `IsEnabled(…)` concurrently as fast as it can, and the results are pretty clear. (Running the benchmark with metrics disabled does not cause any kind of backup.)

### Without the patch

On my 2021 MacBook Pro with an M1 Max and 64 GB memory, I start reliably seeing `IsEnabled(…)` calls taking `>= 50 ms` around the 50 000 iteration mark (17.76 % in this example):

```
$ go test -bench=. -test.bench '^BenchmarkMetrics_IsEnabled$' -test.benchtime '50000x' -test.run '^$'

goos: darwin
goarch: arm64
pkg: github.com/Unleash/unleash-go-sdk/v5
cpu: Apple M1 Max
BenchmarkMetrics_IsEnabled-10    	   50000	      1801 ns/op
--- BENCH: BenchmarkMetrics_IsEnabled-10
    metrics_test.go:312: Calls over threshold of 50 ms: 8881 / 50000 (17.76 %)
PASS
ok  	github.com/Unleash/unleash-go-sdk/v5	0.361s
```

From there on, it gets worse. The issue cascades from the first backup, and so 100 000 iterations causes more than half the calls to take `>= 50 ms` (68.86 %):

```
$ go test -bench=. -test.bench '^BenchmarkMetrics_IsEnabled$' -test.benchtime '100000x' -test.run '^$'

[…]
BenchmarkMetrics_IsEnabled-10    	  100000	      2134 ns/op
--- BENCH: BenchmarkMetrics_IsEnabled-10
    metrics_test.go:312: Calls over threshold of 50 ms: 68863 / 100000 (68.86 %)
PASS
ok  	github.com/Unleash/unleash-go-sdk/v5	0.506s
```

A million iterations backs everything up for pretty much the full benchmark (98.71 %):

```
$ go test -bench=. -test.bench '^BenchmarkMetrics_IsEnabled$' -test.benchtime '1000000x' -test.run '^$'

[…]
BenchmarkMetrics_IsEnabled-10    	 1000000	      1776 ns/op
--- BENCH: BenchmarkMetrics_IsEnabled-10
    metrics_test.go:312: Calls over threshold of 50 ms: 987137 / 1000000 (98.71 %)
PASS
ok  	github.com/Unleash/unleash-go-sdk/v5	2.522s
```

### With the patch

Running the metrics stuff in a goroutine instead of a deferred (but blocking) function makes a million iterations work just fine. I typically see 0 calls take more than 50ms (though I sometimes get 1 or 2). Increasing the threshold a little bit to 80 ms gives me a consistent 0. Here's an example:

```
$ go test -bench=. -test.bench '^BenchmarkMetrics_IsEnabled$' -test.benchtime '1000000x' -test.run '^$'

[…]
BenchmarkMetrics_IsEnabled-10    	 1000000	      1056 ns/op
--- BENCH: BenchmarkMetrics_IsEnabled-10
    metrics_test.go:312: Calls over threshold of 50 ms: 0 / 1000000 (0.00 %)
PASS
ok  	github.com/Unleash/unleash-go-sdk/v5	1.335s
```

(Also note that the mean `ns/op` drops from around 1800 to around 1200.)

## Discussion points

### Metrics might be dropped on shutdown

This implementation records metrics in an async fashion. If the client is `Close()`d while there are active goroutines waiting to record metrics, those metrics get dropped.

On my machine, I need tens of thousands of active goroutines to trigger this behaviour. I think dropping the metrics is that case is fine. What do you think?

### This implementation is unbounded

This patch is small and easy to reason about, and fixes the issue from the perspective of the benchmark – but the waiting still happens! I just made it no longer block `IsEnabled(…)` from returning.

In a high-pressure environment with a very high active goroutine count, the unbounded nature of this implementation might make the problem gradually worse by scheduling more and more goroutines until the instance eventually runs out of memory (or some other resource).

To be honest, I don't think this general problem has a real solution – other than the current implementation, which also isn't great.

I consider this type of consistently high-pressure environment unreasonable. While I can totally see this happening for a short time during a traffic spike or scheduled task, I don't see any reason for a single instance to concurrently call `IsEnabled(…)` enough times that this ever becomes a real problem.

If this is indeed problematic, a bounded worker pool may be a better approach – probably on the consumer side of the channel, which receives the messages and writes the data. On the other hand, it might be just as effective to buffer the channel, as described below.

### Buffer the channel instead?

One other option would be to buffer the metrics `count` channel. It's currently unbuffered:

https://github.com/Unleash/unleash-go-sdk/blob/40bd14135f7339a5284a1db75bf6aa387929553b/client.go#L114

Changing `make(chan metric)` to `make(chan metric, 1_000_000)` also makes the one-million iteration benchmark pass with flying colours. That approach is also problematic, though:

1. It allocates a _bunch_ of unnecessary memory (the whole buffer gets allocated up-front);
2. The required buffer size scales more or less linearly with the traffic;
3. It feels like way too much of an implementation detail to expose (in my opinion).

**On the other hand**, the benchmark sets up ridiculously extreme conditions. I suspect that a real environment that triggers this behaviour does not actually hammer the Unleash client with `IsEnabled(…)` calls, but instead has a very high number of goroutines doing other things that cause the metrics-count-receiver to not be scheduled in time. 

For a real production environment, it might be possible to circumvent the whole issue by adding a relatively small channel buffer (in the tens or hundreds).

### Conclusion

Still, I think this PR is the okay-est solution to the issue at hand – and as mentioned, it looks to be in line with the intention behind the current code :smile:

What do you think?