### PR TITLE
chore: reduce allocations

### DIFF
--- a/internal/strategies/helpers.go
+++ b/internal/strategies/helpers.go
@@ -11,6 +11,16 @@ import (
 )
 
 var VariantNormalizationSeed uint32 = 86028157
+var randStrings [10001]string
+
+// Precompute a lookup table of random strings from "1" to "10000"
+// Generating string garbage is expensive in hot loops
+// Dumps ~200k into resident but that's small enough to not cry
+func init() {
+	for i := 1; i <= 10000; i++ {
+		randStrings[i] = strconv.Itoa(i)
+	}
+}
 
 func resolveHostname() (string, error) {
 	var err error
@@ -46,11 +56,36 @@ func normalizedRolloutValue(id string, groupId string) uint32 {
 	return NormalizedVariantValue(id, groupId, 100, 0)
 }
 
-func NormalizedVariantValue(id string, groupId string, normalizer int, seed uint32) uint32 {
-	hash := murmur3.SeedNew32(seed)
-	hash.Write([]byte(groupId + ":" + id))
-	hashCode := hash.Sum32()
-	return hashCode%uint32(normalizer) + 1
+// This comment exists for the purposes of preventing a future maintainer from "simplifying" this function
+// If you want to do that, please benchmark your resulting code for allocations
+//
+// We're gonna do something a little different from other SDKs here to avoid allocations
+// Typically an SDK concatenates a bunch of strings and applies a murmur3 hash to the result
+// That's surprisingly expensive in Go. So for cases where we know the input fits into
+// a 256 byte buffer, we can avoid allocations entirely and just use a stack buffer.
+// In practice that's most cases.
+func NormalizedVariantValue(id, groupId string, normalizer int, seed uint32) uint32 {
+	n := len(groupId) + 1 + len(id)
+
+	// So if we assume that this all fits into 256 bytes, we can do this on the stack!
+	if n <= 256 {
+		var buf [256]byte
+		i := copy(buf[:], groupId)
+		buf[i] = ':'
+		i++
+		i += copy(buf[i:], id)
+		x := murmur3.SeedSum32(seed, buf[:i])
+		return (x % uint32(normalizer)) + 1
+	}
+
+	// ...but of course life doesn't work like that so we still need a fallback
+	b := make([]byte, n)
+	i := copy(b, groupId)
+	b[i] = ':'
+	i++
+	copy(b[i:], id)
+	x := murmur3.SeedSum32(seed, b)
+	return (x % uint32(normalizer)) + 1
 }
 
 // coalesce returns the first non-empty string in the list of arguments
@@ -100,6 +135,5 @@ func randomString() string {
 	r := rngPool.Get().(*rand.Rand)
 	n := r.IntN(10000) + 1
 	rngPool.Put(r)
-
-	return strconv.Itoa(n)
+	return randStrings[n]
 }


### PR DESCRIPTION
Memory profiling shows the string generation in the isEnabled hot path as being on of the major sources of allocations. This does two things which both change the path to heap allocation free on the happy path. 

First is to precompute a random number lookup table ahead of time. Previously when we needed a random number, we'd generate a number between 1 and 10001 and then convert that to a string. That's a bit expensive. This trades off around 200K of resident memory for an allocation free random number fetch (guesstimate here, 4bytes average for the content + 1 word pointer + 1 word length).

The second significant thing here is the way we're using the murmur hash library. Generating a bunch of strings and then streaming the bytes in means a ton of copying. Instead we can not do that and pass in a stack allocated buffer. 

The murmurhash issue is pretty obvious from a a pprof heap profile:

Type: alloc_space
Time: 2026-01-16 16:19:46 SAST
Showing nodes accounting for 3253.18MB, 98.98% of 3286.83MB total
Dropped 123 nodes (cum <= 16.43MB)
      flat  flat%   sum%        cum   cum%
 1983.15MB 60.34% 60.34%  1983.15MB 60.34%  github.com/twmb/murmur3.SeedNew32
  791.02MB 24.07% 84.40%  3255.69MB 99.05%  github.com/Unleash/unleash-go-sdk/v5.(*Client).isEnabled
  392.01MB 11.93% 96.33%  2375.16MB 72.26%  github.com/Unleash/unleash-go-sdk/v5/internal/strategies.NormalizedVariantValue
      87MB  2.65% 98.98%       87MB  2.65%  strconv.formatBits
         0     0% 98.98%  3255.69MB 99.05%  github.com/Unleash/unleash-go-sdk/v5.(*Client).IsEnabled
         
Digging deeper on the isEnabled call surfaces the random string gen issue. Apparently I'm a dummy and didn't save the profile but if anyone's curious, ask and I'll recreate
 