### PR TITLE
chore: rework public api to reduce allocations

### DIFF
--- a/client.go
+++ b/client.go
@@ -337,7 +337,6 @@ func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (
 	return
 }
 
-// IsEnabledWithOptions is the hot-path friendly API.
 func (uc *Client) isEnabledWithOptions(
 	feature string,
 	snapshot *FeatureMemoryState,

--- a/client.go
+++ b/client.go
@@ -321,9 +321,7 @@ func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (
 
 		if f != nil && f.ImpressionData && uc.impressionListener != nil {
 			ctx := uc.staticContext
-			if options.HasCtx {
-				ctx = ctx.Override(options.Ctx)
-			}
+			ctx = ctx.Override(options.Ctx)
 
 			uc.impression <- ImpressionEvent{
 				FeatureName: feature,
@@ -344,28 +342,15 @@ func (uc *Client) isEnabledWithOptions(
 ) (api.StrategyResult, *api.Feature) {
 	var internal featureOption
 
-	if opts.HasFallback {
-		fb := opts.Fallback
-		internal.fallback = &fb
-	}
-
-	if opts.FallbackFunc != nil {
-		internal.fallbackFunc = opts.FallbackFunc
-	}
-	if opts.Resolver != nil {
-		internal.resolver = opts.Resolver
-	}
-	if opts.HasCtx {
-		ctx := opts.Ctx
-		internal.ctx = &ctx
-	}
+	internal.fallback = opts.Fallback
+	internal.fallbackFunc = opts.FallbackFunc
+	internal.resolver = opts.Resolver
+	internal.resolver = opts.Resolver
 
 	f := resolveToggle(snapshot, internal, feature)
 
 	ctx := uc.staticContext
-	if internal.ctx != nil {
-		ctx = ctx.Override(*internal.ctx)
-	}
+	ctx = ctx.Override(opts.Ctx)
 
 	if f == nil {
 		return handleFallback(internal, feature, ctx), nil
@@ -416,6 +401,83 @@ func (uc *Client) isEnabled(feature string, snapshot *FeatureMemoryState, option
 	}
 
 	return result, f
+}
+
+func (uc *Client) GetVariantWithOptions(feature string, options VariantOptions) (variant *api.Variant) {
+	snapshot := uc.repository.snapshot()
+	variant = uc.getVariantWithOptions(feature, snapshot, options)
+
+	defer func() {
+		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
+
+		f := snapshot.Features[feature]
+		if f != nil && f.ImpressionData && uc.impressionListener != nil {
+			ctx := uc.staticContext
+			ctx = ctx.Override(options.Ctx)
+
+			uc.impression <- ImpressionEvent{
+				FeatureName: feature,
+				EventType:   ImpressionEventTypeGetVariant,
+				Enabled:     variant.FeatureEnabled,
+				Variant:     variant.Name,
+				Context:     ctx,
+			}
+		}
+	}()
+	return
+}
+
+func (uc *Client) getVariantWithOptions(feature string, snapshot *FeatureMemoryState, opts VariantOptions) *api.Variant {
+	internal := variantOption{}
+
+	internal.variantFallback = opts.VariantFallback
+	internal.variantFallbackFunc = opts.VariantFallbackFunc
+	internal.resolver = opts.Resolver
+	internal.ctx = &opts.Ctx
+
+	ctx := uc.staticContext
+	ctx = ctx.Override(opts.Ctx)
+
+	var strategyResult api.StrategyResult
+	var f *api.Feature
+	strategyResult, f = uc.isEnabledWithOptions(feature, snapshot, FeatureOptions{
+		Ctx:      *ctx,
+		Resolver: internal.resolver,
+	})
+
+	getFallbackVariant := func(featureEnabled bool) *api.Variant {
+		if internal.variantFallbackFunc != nil {
+			return internal.variantFallbackFunc(feature, ctx)
+		} else if internal.variantFallback != nil {
+			return internal.variantFallback
+		}
+
+		if featureEnabled {
+			return disabledVariantFeatureEnabled
+		}
+		return api.GetDefaultVariant()
+	}
+
+	if !strategyResult.Enabled {
+		return getFallbackVariant(false)
+	}
+
+	if f == nil || !f.Enabled {
+		return getFallbackVariant(false)
+	}
+
+	if strategyResult.Variant != nil {
+		return strategyResult.Variant
+	}
+
+	if len(f.Variants) == 0 {
+		return getFallbackVariant(true)
+	}
+
+	return api.VariantCollection{
+		GroupId:  f.Name,
+		Variants: f.Variants,
+	}.GetVariant(ctx, nil)
 }
 
 // GetVariant queries a variant as the specified feature is enabled.

--- a/client.go
+++ b/client.go
@@ -311,12 +311,86 @@ func (uc *Client) IsEnabled(feature string, options ...FeatureOption) (enabled b
 	return
 }
 
+func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (enabled bool) {
+	snapshot := uc.repository.snapshot()
+	result, f := uc.isEnabledWithOptions(feature, snapshot, options)
+	enabled = result.Enabled
+
+	defer func() {
+		uc.metrics.count(feature, enabled)
+
+		if f != nil && f.ImpressionData && uc.impressionListener != nil {
+			ctx := uc.staticContext
+			if options.HasCtx {
+				ctx = ctx.Override(options.Ctx)
+			}
+
+			uc.impression <- ImpressionEvent{
+				FeatureName: feature,
+				EventType:   ImpressionEventTypeIsEnabled,
+				Enabled:     enabled,
+				Context:     ctx,
+			}
+		}
+	}()
+
+	return
+}
+
+// IsEnabledWithOptions is the hot-path friendly API.
+func (uc *Client) isEnabledWithOptions(
+	feature string,
+	snapshot *FeatureMemoryState,
+	opts FeatureOptions,
+) (api.StrategyResult, *api.Feature) {
+	var internal featureOption
+
+	if opts.HasFallback {
+		fb := opts.Fallback
+		internal.fallback = &fb
+	}
+
+	if opts.FallbackFunc != nil {
+		internal.fallbackFunc = opts.FallbackFunc
+	}
+	if opts.Resolver != nil {
+		internal.resolver = opts.Resolver
+	}
+	if opts.HasCtx {
+		ctx := opts.Ctx
+		internal.ctx = &ctx
+	}
+
+	f := resolveToggle(snapshot, internal, feature)
+
+	ctx := uc.staticContext
+	if internal.ctx != nil {
+		ctx = ctx.Override(*internal.ctx)
+	}
+
+	if f == nil {
+		return handleFallback(internal, feature, ctx), nil
+	}
+
+	result, err := snapshot.evaluateFeature(f, ctx, uc.strategies)
+	if err != nil {
+		uc.errors <- err
+		return api.StrategyResult{Enabled: false}, f
+	}
+
+	return result, f
+}
+
 // isEnabled abstracts away the details of checking if a toggle is turned on or off
 // without metrics
 func (uc *Client) isEnabled(feature string, snapshot *FeatureMemoryState, options ...FeatureOption) (api.StrategyResult, *api.Feature) {
 	var opts featureOption
-	for _, o := range options {
-		o(&opts)
+	if len(options) != 0 {
+		local := featureOption{}
+		for _, o := range options {
+			o(&local)
+		}
+		opts = local
 	}
 
 	// Because we're not reading directly from the snapshot, we run the risk of getting a torn feature response - one where

--- a/config.go
+++ b/config.go
@@ -173,6 +173,17 @@ type featureOption struct {
 	resolver     FeatureResolver
 }
 
+type FeatureOptions struct {
+	Ctx    context.Context
+	HasCtx bool
+
+	Fallback    bool
+	HasFallback bool
+
+	FallbackFunc FallbackFunc
+	Resolver     FeatureResolver
+}
+
 // FeatureOption provides options for querying if a feature is enabled or not.
 type FeatureOption func(*featureOption)
 

--- a/config.go
+++ b/config.go
@@ -174,14 +174,17 @@ type featureOption struct {
 }
 
 type FeatureOptions struct {
-	Ctx    context.Context
-	HasCtx bool
-
-	Fallback    bool
-	HasFallback bool
-
+	Ctx          context.Context
+	Fallback     *bool
 	FallbackFunc FallbackFunc
 	Resolver     FeatureResolver
+}
+
+type VariantOptions struct {
+	Ctx                 context.Context
+	VariantFallback     *api.Variant
+	VariantFallbackFunc VariantFallbackFunc
+	Resolver            FeatureResolver
 }
 
 // FeatureOption provides options for querying if a feature is enabled or not.

--- a/spec_test.go
+++ b/spec_test.go
@@ -69,7 +69,7 @@ func (tc TestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.IsEnabled(tc.ToggleName, WithContext(tc.Context))
+			client.IsEnabledWithOptions(tc.ToggleName, FeatureOptions{Ctx: tc.Context})
 			wg.Done()
 		}()
 		result := client.IsEnabled(tc.ToggleName, WithContext(tc.Context))
@@ -91,10 +91,10 @@ func (vtc VariantTestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.GetVariant(vtc.ToggleName, WithVariantContext(vtc.Context))
+			client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 			wg.Done()
 		}()
-		result := client.GetVariant(vtc.ToggleName, WithVariantContext(vtc.Context))
+		result := client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 		wg.Wait()
 		assert.Equal(t, vtc.ExpectedResult.Enabled, result.Enabled)
 		// copy over the FeatureEnabled field with different JSON tag


### PR DESCRIPTION
This reworks the public API to not use a functional interface to pass options. That pattern is ergonomically nice but requires that the compiler do a bunch of moves of that data as we compute the actual values. Turns out that's super expensive.

Not convinced this is the API that we want. I am open to suggestions. Please! 

Combined with #220, this massively reduces the allocations on the isEnabled hot path.

Size allocations after this and #220 - isEnabled no longer appears here :smile:  :

There's potentially more we can do here but I think a reduction of several gigabytes to unnoticeable is probably good enough for this pass

Type: alloc_space
Time: 2026-01-16 16:29:57 SAST
Showing nodes accounting for 18262.89kB, 100% of 18262.89kB total
      flat  flat%   sum%        cum   cum%
    3591kB 19.66% 19.66%     3591kB 19.66%  runtime.allocm
 2048.16kB 11.21% 30.88%  2048.16kB 11.21%  crypto/x509.parseName
 1974.97kB 10.81% 41.69%  1974.97kB 10.81%  bytes.growSlice
 1928.99kB 10.56% 52.25%  1928.99kB 10.56%  reflect.growslice
 1025.50kB  5.62% 57.87%  5634.09kB 30.85%  crypto/x509.parseCertificate
 1025.31kB  5.61% 63.48%  1025.31kB  5.61%  encoding/pem.Decode
 1024.09kB  5.61% 69.09%  1024.09kB  5.61%  crypto/x509/pkix.(*Name).FillFromRDNSequence
 1000.34kB  5.48% 74.57%  2757.67kB 15.10%  main.main
  544.67kB  2.98% 77.55%   544.67kB  2.98%  net.open
  515.19kB  2.82% 80.37%   515.19kB  2.82%  unicode.map.init.2
  512.28kB  2.81% 83.18%   512.28kB  2.81%  math/big.nat.make (inline)
  512.22kB  2.80% 85.98%   512.22kB  2.80%  runtime.malg
  512.09kB  2.80% 88.79%   512.09kB  2.80%  github.com/Unleash/unleash-go-sdk/v5/api.FeatureResponse.FeatureMap (inline)
  512.03kB  2.80% 91.59%   512.03kB  2.80%  vendor/golang.org/x/crypto/cryptobyte.(*String).ReadASN1ObjectIdentifier
  512.02kB  2.80% 94.39%   512.02kB  2.80%  crypto/x509.processExtensions
  512.01kB  2.80% 97.20%  1056.67kB  5.79%  main.main.func1
  512.01kB  2.80%   100%   512.01kB  2.80%  runtime.(*timers).addHeap
         0     0%   100%   514.38kB  2.82%  bytes.(*Buffer).Grow (inline)
         0     0%   100%  1460.59kB  8.00%  bytes.(*Buffer).Write
         0     0%   100%  1974.97kB 10.81%  bytes.(*Buffer).grow
         0     0%   100%  7173.78kB 39.28%  crypto/tls.(*Conn).HandshakeContext (inline)
         0     0%   100%  7173.78kB 39.28%  crypto/tls.(*Conn).clientHandshake
         0     0%   100%  7173.78kB 39.28%  crypto/tls.(*Conn).handshakeContext
         0     0%   100%   514.38kB  2.82%  crypto/tls.(*Conn).readFromUntil
         0     0%   100%   514.38kB  2.82%  crypto/tls.(*Conn).readHandshake
         0     0%   100%   514.38kB  2.82%  crypto/tls.(*Conn).readHandshakeBytes
         0     0%   100%   514.38kB  2.82%  crypto/tls.(*Conn).readRecord (inline)
         0     0%   100%   514.38kB  2.82%  crypto/tls.(*Conn).readRecordOrCCS
         0     0%   100%  6659.41kB 36.46%  crypto/tls.(*Conn).verifyServerCertificate
         0     0%   100%  7173.78kB 39.28%  crypto/tls.(*clientHandshakeStateTLS13).handshake
         0     0%   100%  7173.78kB 39.28%  crypto/tls.(*clientHandshakeStateTLS13).readServerCertificate
         0     0%   100%  6659.41kB 36.46%  crypto/x509.(*CertPool).AppendCertsFromPEM
         0     0%   100%  6659.41kB 36.46%  crypto/x509.(*Certificate).Verify
         0     0%   100%  5634.09kB 30.85%  crypto/x509.ParseCertificate
         0     0%   100%  6659.41kB 36.46%  crypto/x509.initSystemRoots
         0     0%   100%  6659.41kB 36.46%  crypto/x509.loadSystemRoots
         0     0%   100%   512.03kB  2.80%  crypto/x509.parseAI
         0     0%   100%   512.28kB  2.81%  crypto/x509.parsePublicKey
         0     0%   100%  6659.41kB 36.46%  crypto/x509.systemRootsPool
         0     0%   100%  1928.99kB 10.56%  encoding/json.(*Decoder).Decode
         0     0%   100%  1460.59kB  8.00%  encoding/json.(*Encoder).Encode
         0     0%   100%  1928.99kB 10.56%  encoding/json.(*decodeState).array
         0     0%   100%  1928.99kB 10.56%  encoding/json.(*decodeState).object
         0     0%   100%  1928.99kB 10.56%  encoding/json.(*decodeState).unmarshal
         0     0%   100%  1928.99kB 10.56%  encoding/json.(*decodeState).value
         0     0%   100%  1460.59kB  8.00%  encoding/json.(*encodeState).marshal
         0     0%   100%  1460.59kB  8.00%  encoding/json.(*encodeState).reflectValue
         0     0%   100%  1460.59kB  8.00%  encoding/json.arrayEncoder.encode
         0     0%   100%   650.62kB  3.56%  encoding/json.boolEncoder
         0     0%   100%  1460.59kB  8.00%  encoding/json.ptrEncoder.encode
         0     0%   100%  1460.59kB  8.00%  encoding/json.sliceEncoder.encode
         0     0%   100%   809.97kB  4.44%  encoding/json.stringEncoder
         0     0%   100%  1460.59kB  8.00%  encoding/json.structEncoder.encode
         0     0%   100%  1245.25kB  6.82%  github.com/Unleash/unleash-go-sdk/v5.(*DefaultStorage).Load
         0     0%   100%  1460.59kB  8.00%  github.com/Unleash/unleash-go-sdk/v5.(*DefaultStorage).Persist
         0     0%   100%  2144.34kB 11.74%  github.com/Unleash/unleash-go-sdk/v5.(*repository).fetch
         0     0%   100%  2144.34kB 11.74%  github.com/Unleash/unleash-go-sdk/v5.(*repository).fetchAndReportError
         0     0%   100%  1460.59kB  8.00%  github.com/Unleash/unleash-go-sdk/v5.(*repository).saveState
         0     0%   100%  2144.34kB 11.74%  github.com/Unleash/unleash-go-sdk/v5.(*repository).sync
         0     0%   100%   512.09kB  2.80%  github.com/Unleash/unleash-go-sdk/v5.(*repository).updateState
         0     0%   100%  1757.33kB  9.62%  github.com/Unleash/unleash-go-sdk/v5.NewClient
         0     0%   100%  1757.33kB  9.62%  github.com/Unleash/unleash-go-sdk/v5.newRepository

