### PR TITLE
chore: clean up public api

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -60,7 +60,7 @@ func BenchmarkFeatureToggleEvaluation(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_ = unleash.IsEnabled("foo")
+		_ = unleash.IsEnabled("foo", unleash.FeatureOptions{})
 	}
 
 	endTime := time.Now()

--- a/client.go
+++ b/client.go
@@ -337,7 +337,6 @@ func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (
 	return
 }
 
-// IsEnabledWithOptions is the hot-path friendly API.
 func (uc *Client) isEnabledWithOptions(
 	feature string,
 	snapshot *FeatureMemoryState,

--- a/client.go
+++ b/client.go
@@ -321,9 +321,7 @@ func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (
 
 		if f != nil && f.ImpressionData && uc.impressionListener != nil {
 			ctx := uc.staticContext
-			if options.HasCtx {
-				ctx = ctx.Override(options.Ctx)
-			}
+			ctx = ctx.Override(options.Ctx)
 
 			uc.impression <- ImpressionEvent{
 				FeatureName: feature,
@@ -344,28 +342,15 @@ func (uc *Client) isEnabledWithOptions(
 ) (api.StrategyResult, *api.Feature) {
 	var internal featureOption
 
-	if opts.HasFallback {
-		fb := opts.Fallback
-		internal.fallback = &fb
-	}
-
-	if opts.FallbackFunc != nil {
-		internal.fallbackFunc = opts.FallbackFunc
-	}
-	if opts.Resolver != nil {
-		internal.resolver = opts.Resolver
-	}
-	if opts.HasCtx {
-		ctx := opts.Ctx
-		internal.ctx = &ctx
-	}
+	internal.fallback = opts.Fallback
+	internal.fallbackFunc = opts.FallbackFunc
+	internal.resolver = opts.Resolver
+	internal.resolver = opts.Resolver
 
 	f := resolveToggle(snapshot, internal, feature)
 
 	ctx := uc.staticContext
-	if internal.ctx != nil {
-		ctx = ctx.Override(*internal.ctx)
-	}
+	ctx = ctx.Override(opts.Ctx)
 
 	if f == nil {
 		return handleFallback(internal, feature, ctx), nil
@@ -416,6 +401,83 @@ func (uc *Client) isEnabled(feature string, snapshot *FeatureMemoryState, option
 	}
 
 	return result, f
+}
+
+func (uc *Client) GetVariantWithOptions(feature string, options VariantOptions) (variant *api.Variant) {
+	snapshot := uc.repository.snapshot()
+	variant = uc.getVariantWithOptions(feature, snapshot, options)
+
+	defer func() {
+		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
+
+		f := snapshot.Features[feature]
+		if f != nil && f.ImpressionData && uc.impressionListener != nil {
+			ctx := uc.staticContext
+			ctx = ctx.Override(options.Ctx)
+
+			uc.impression <- ImpressionEvent{
+				FeatureName: feature,
+				EventType:   ImpressionEventTypeGetVariant,
+				Enabled:     variant.FeatureEnabled,
+				Variant:     variant.Name,
+				Context:     ctx,
+			}
+		}
+	}()
+	return
+}
+
+func (uc *Client) getVariantWithOptions(feature string, snapshot *FeatureMemoryState, opts VariantOptions) *api.Variant {
+	internal := variantOption{}
+
+	internal.variantFallback = opts.VariantFallback
+	internal.variantFallbackFunc = opts.VariantFallbackFunc
+	internal.resolver = opts.Resolver
+	internal.ctx = &opts.Ctx
+
+	ctx := uc.staticContext
+	ctx = ctx.Override(opts.Ctx)
+
+	var strategyResult api.StrategyResult
+	var f *api.Feature
+	strategyResult, f = uc.isEnabledWithOptions(feature, snapshot, FeatureOptions{
+		Ctx:      *ctx,
+		Resolver: internal.resolver,
+	})
+
+	getFallbackVariant := func(featureEnabled bool) *api.Variant {
+		if internal.variantFallbackFunc != nil {
+			return internal.variantFallbackFunc(feature, ctx)
+		} else if internal.variantFallback != nil {
+			return internal.variantFallback
+		}
+
+		if featureEnabled {
+			return disabledVariantFeatureEnabled
+		}
+		return api.GetDefaultVariant()
+	}
+
+	if !strategyResult.Enabled {
+		return getFallbackVariant(false)
+	}
+
+	if f == nil || !f.Enabled {
+		return getFallbackVariant(false)
+	}
+
+	if strategyResult.Variant != nil {
+		return strategyResult.Variant
+	}
+
+	if len(f.Variants) == 0 {
+		return getFallbackVariant(true)
+	}
+
+	return api.VariantCollection{
+		GroupId:  f.Name,
+		Variants: f.Variants,
+	}.GetVariant(ctx, nil)
 }
 
 // GetVariant queries a variant as the specified feature is enabled.

--- a/client.go
+++ b/client.go
@@ -311,12 +311,86 @@ func (uc *Client) IsEnabled(feature string, options ...FeatureOption) (enabled b
 	return
 }
 
+func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (enabled bool) {
+	snapshot := uc.repository.snapshot()
+	result, f := uc.isEnabledWithOptions(feature, snapshot, options)
+	enabled = result.Enabled
+
+	defer func() {
+		uc.metrics.count(feature, enabled)
+
+		if f != nil && f.ImpressionData && uc.impressionListener != nil {
+			ctx := uc.staticContext
+			if options.HasCtx {
+				ctx = ctx.Override(options.Ctx)
+			}
+
+			uc.impression <- ImpressionEvent{
+				FeatureName: feature,
+				EventType:   ImpressionEventTypeIsEnabled,
+				Enabled:     enabled,
+				Context:     ctx,
+			}
+		}
+	}()
+
+	return
+}
+
+// IsEnabledWithOptions is the hot-path friendly API.
+func (uc *Client) isEnabledWithOptions(
+	feature string,
+	snapshot *FeatureMemoryState,
+	opts FeatureOptions,
+) (api.StrategyResult, *api.Feature) {
+	var internal featureOption
+
+	if opts.HasFallback {
+		fb := opts.Fallback
+		internal.fallback = &fb
+	}
+
+	if opts.FallbackFunc != nil {
+		internal.fallbackFunc = opts.FallbackFunc
+	}
+	if opts.Resolver != nil {
+		internal.resolver = opts.Resolver
+	}
+	if opts.HasCtx {
+		ctx := opts.Ctx
+		internal.ctx = &ctx
+	}
+
+	f := resolveToggle(snapshot, internal, feature)
+
+	ctx := uc.staticContext
+	if internal.ctx != nil {
+		ctx = ctx.Override(*internal.ctx)
+	}
+
+	if f == nil {
+		return handleFallback(internal, feature, ctx), nil
+	}
+
+	result, err := snapshot.evaluateFeature(f, ctx, uc.strategies)
+	if err != nil {
+		uc.errors <- err
+		return api.StrategyResult{Enabled: false}, f
+	}
+
+	return result, f
+}
+
 // isEnabled abstracts away the details of checking if a toggle is turned on or off
 // without metrics
 func (uc *Client) isEnabled(feature string, snapshot *FeatureMemoryState, options ...FeatureOption) (api.StrategyResult, *api.Feature) {
 	var opts featureOption
-	for _, o := range options {
-		o(&opts)
+	if len(options) != 0 {
+		local := featureOption{}
+		for _, o := range options {
+			o(&local)
+		}
+		opts = local
 	}
 
 	// Because we're not reading directly from the snapshot, we run the risk of getting a torn feature response - one where

--- a/client.go
+++ b/client.go
@@ -281,39 +281,9 @@ func (uc *Client) sync() {
 // IsEnabled queries whether the specified feature is enabled or not.
 //
 // It is safe to call this method from multiple goroutines concurrently.
-func (uc *Client) IsEnabled(feature string, options ...FeatureOption) (enabled bool) {
+func (uc *Client) IsEnabled(feature string, options FeatureOptions) (enabled bool) {
 	snapshot := uc.repository.snapshot()
-	result, f := uc.isEnabled(feature, snapshot, options...)
-	enabled = result.Enabled
-
-	defer func() {
-		uc.metrics.count(feature, enabled)
-
-		if f != nil && f.ImpressionData && uc.impressionListener != nil {
-			var opts featureOption
-			for _, o := range options {
-				o(&opts)
-			}
-			ctx := uc.staticContext
-			if opts.ctx != nil {
-				ctx = ctx.Override(*opts.ctx)
-			}
-
-			uc.impression <- ImpressionEvent{
-				FeatureName: feature,
-				EventType:   ImpressionEventTypeIsEnabled,
-				Enabled:     enabled,
-				Context:     ctx,
-			}
-		}
-	}()
-
-	return
-}
-
-func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (enabled bool) {
-	snapshot := uc.repository.snapshot()
-	result, f := uc.isEnabledWithOptions(feature, snapshot, options)
+	result, f := uc.isEnabled(feature, snapshot, options)
 	enabled = result.Enabled
 
 	defer func() {
@@ -335,25 +305,20 @@ func (uc *Client) IsEnabledWithOptions(feature string, options FeatureOptions) (
 	return
 }
 
-func (uc *Client) isEnabledWithOptions(
+// isEnabled abstracts away the details of checking if a toggle is turned on or off
+// without metrics
+func (uc *Client) isEnabled(
 	feature string,
 	snapshot *FeatureMemoryState,
 	opts FeatureOptions,
 ) (api.StrategyResult, *api.Feature) {
-	var internal featureOption
-
-	internal.fallback = opts.Fallback
-	internal.fallbackFunc = opts.FallbackFunc
-	internal.resolver = opts.Resolver
-	internal.resolver = opts.Resolver
-
-	f := resolveToggle(snapshot, internal, feature)
+	f := resolveToggle(snapshot, opts.Resolver, feature)
 
 	ctx := uc.staticContext
 	ctx = ctx.Override(opts.Ctx)
 
 	if f == nil {
-		return handleFallback(internal, feature, ctx), nil
+		return handleFallback(opts.FallbackFunc, opts.Fallback, feature, ctx), nil
 	}
 
 	result, err := snapshot.evaluateFeature(f, ctx, uc.strategies)
@@ -365,47 +330,12 @@ func (uc *Client) isEnabledWithOptions(
 	return result, f
 }
 
-// isEnabled abstracts away the details of checking if a toggle is turned on or off
-// without metrics
-func (uc *Client) isEnabled(feature string, snapshot *FeatureMemoryState, options ...FeatureOption) (api.StrategyResult, *api.Feature) {
-	var opts featureOption
-	if len(options) != 0 {
-		local := featureOption{}
-		for _, o := range options {
-			o(&local)
-		}
-		opts = local
-	}
-
-	// Because we're not reading directly from the snapshot, we run the risk of getting a torn feature response - one where
-	// a segment is not in sync with the feature requesting it. However, that problem has existed since the feature resolver feature was added.
-	// That feature exists to work around a performance problem where a custom storage implementation wasn't caching.
-	// However that problem should no longer exist since storage is no longer the caching layer and so this code path should be deprecated in the future.
-	f := resolveToggle(snapshot, opts, feature)
-
-	ctx := uc.staticContext
-	if opts.ctx != nil {
-		ctx = ctx.Override(*opts.ctx)
-	}
-
-	if f == nil {
-		return handleFallback(opts, feature, ctx), nil
-	}
-
-	result, err := snapshot.evaluateFeature(f, ctx, uc.strategies)
-	if err != nil {
-		uc.errors <- err
-		return api.StrategyResult{
-			Enabled: false,
-		}, f
-	}
-
-	return result, f
-}
-
-func (uc *Client) GetVariantWithOptions(feature string, options VariantOptions) (variant *api.Variant) {
+// GetVariant queries a variant as the specified feature is enabled.
+//
+// It is safe to call this method from multiple goroutines concurrently.
+func (uc *Client) GetVariant(feature string, options VariantOptions) (variant *api.Variant) {
 	snapshot := uc.repository.snapshot()
-	variant = uc.getVariantWithOptions(feature, snapshot, options)
+	variant = uc.getVariant(feature, snapshot, options)
 
 	defer func() {
 		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
@@ -427,7 +357,7 @@ func (uc *Client) GetVariantWithOptions(feature string, options VariantOptions) 
 	return
 }
 
-func (uc *Client) getVariantWithOptions(feature string, snapshot *FeatureMemoryState, opts VariantOptions) *api.Variant {
+func (uc *Client) getVariant(feature string, snapshot *FeatureMemoryState, opts VariantOptions) *api.Variant {
 	internal := variantOption{}
 
 	internal.variantFallback = opts.VariantFallback
@@ -440,7 +370,7 @@ func (uc *Client) getVariantWithOptions(feature string, snapshot *FeatureMemoryS
 
 	var strategyResult api.StrategyResult
 	var f *api.Feature
-	strategyResult, f = uc.isEnabledWithOptions(feature, snapshot, FeatureOptions{
+	strategyResult, f = uc.isEnabled(feature, snapshot, FeatureOptions{
 		Ctx:      *ctx,
 		Resolver: internal.resolver,
 	})
@@ -456,95 +386,6 @@ func (uc *Client) getVariantWithOptions(feature string, snapshot *FeatureMemoryS
 			return disabledVariantFeatureEnabled
 		}
 		return api.GetDefaultVariant()
-	}
-
-	if !strategyResult.Enabled {
-		return getFallbackVariant(false)
-	}
-
-	if f == nil || !f.Enabled {
-		return getFallbackVariant(false)
-	}
-
-	if strategyResult.Variant != nil {
-		return strategyResult.Variant
-	}
-
-	if len(f.Variants) == 0 {
-		return getFallbackVariant(true)
-	}
-
-	return api.VariantCollection{
-		GroupId:  f.Name,
-		Variants: f.Variants,
-	}.GetVariant(ctx, nil)
-}
-
-// GetVariant queries a variant as the specified feature is enabled.
-//
-// It is safe to call this method from multiple goroutines concurrently.
-func (uc *Client) GetVariant(feature string, options ...VariantOption) (variant *api.Variant) {
-	snapshot := uc.repository.snapshot()
-	variant = uc.getVariantWithoutMetrics(feature, snapshot, options...)
-
-	defer func() {
-		uc.metrics.countVariants(feature, variant.FeatureEnabled, variant.Name)
-
-		f := snapshot.Features[feature]
-		if f != nil && f.ImpressionData && uc.impressionListener != nil {
-			var opts variantOption
-			for _, o := range options {
-				o(&opts)
-			}
-			ctx := uc.staticContext
-			if opts.ctx != nil {
-				ctx = ctx.Override(*opts.ctx)
-			}
-
-			uc.impression <- ImpressionEvent{
-				FeatureName: feature,
-				EventType:   ImpressionEventTypeGetVariant,
-				Enabled:     variant.FeatureEnabled,
-				Variant:     variant.Name,
-				Context:     ctx,
-			}
-		}
-	}()
-	return
-}
-
-// getVariantWithoutMetrics abstracts away the logic for resolving a variant without metrics
-func (uc *Client) getVariantWithoutMetrics(feature string, snapshot *FeatureMemoryState, options ...VariantOption) *api.Variant {
-	defaultVariant := api.GetDefaultVariant()
-	var opts variantOption
-	for _, o := range options {
-		o(&opts)
-	}
-
-	ctx := uc.staticContext
-	if opts.ctx != nil {
-		ctx = ctx.Override(*opts.ctx)
-	}
-
-	var strategyResult api.StrategyResult
-	var f *api.Feature
-	if opts.resolver != nil {
-		strategyResult, f = uc.isEnabled(feature, snapshot, WithContext(*ctx), WithResolver(opts.resolver))
-	} else {
-		strategyResult, f = uc.isEnabled(feature, snapshot, WithContext(*ctx))
-	}
-
-	getFallbackVariant := func(featureEnabled bool) *api.Variant {
-		if opts.variantFallbackFunc != nil {
-			return opts.variantFallbackFunc(feature, ctx)
-		} else if opts.variantFallback != nil {
-			return opts.variantFallback
-		}
-
-		if featureEnabled {
-			return disabledVariantFeatureEnabled
-		}
-		return defaultVariant
 	}
 
 	if !strategyResult.Enabled {
@@ -643,14 +484,14 @@ func (uc *Client) ListFeatures() []api.Feature {
 	return uc.repository.list()
 }
 
-func handleFallback(opts featureOption, featureName string, ctx *context.Context) api.StrategyResult {
-	if opts.fallbackFunc != nil {
+func handleFallback(fallbackFunc FallbackFunc, fallback *bool, featureName string, ctx *context.Context) api.StrategyResult {
+	if fallbackFunc != nil {
 		return api.StrategyResult{
-			Enabled: opts.fallbackFunc(featureName, ctx),
+			Enabled: fallbackFunc(featureName, ctx),
 		}
-	} else if opts.fallback != nil {
+	} else if fallback != nil {
 		return api.StrategyResult{
-			Enabled: *opts.fallback,
+			Enabled: *fallback,
 		}
 	}
 
@@ -659,9 +500,9 @@ func handleFallback(opts featureOption, featureName string, ctx *context.Context
 	}
 }
 
-func resolveToggle(snapshot *FeatureMemoryState, opts featureOption, featureName string) *api.Feature {
-	if opts.resolver != nil {
-		return opts.resolver(featureName)
+func resolveToggle(snapshot *FeatureMemoryState, resolver FeatureResolver, featureName string) *api.Feature {
+	if resolver != nil {
+		return resolver(featureName)
 	} else {
 		return snapshot.Features[featureName]
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -77,7 +77,7 @@ func TestClient_WithFallbackFunc(t *testing.T) {
 		return f == feature
 	}
 
-	isEnabled := client.IsEnabled("does_not_exist", WithFallbackFunc(fallback))
+	isEnabled := client.IsEnabled("does_not_exist", FeatureOptions{FallbackFunc: fallback})
 	assert.True(isEnabled)
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
@@ -140,7 +140,7 @@ func TestClient_WithResolver(t *testing.T) {
 		}
 	}
 
-	isEnabled := client.IsEnabled(feature, WithResolver(resolver))
+	isEnabled := client.IsEnabled(feature, FeatureOptions{Resolver: resolver})
 	assert.True(isEnabled)
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
@@ -350,24 +350,28 @@ func TestClientWithVariantContext(t *testing.T) {
 
 	client.WaitForReady()
 
-	defaultVariant := client.GetVariant("feature-name")
+	defaultVariant := client.GetVariant("feature-name", VariantOptions{})
 
 	assert.Equal(api.GetDefaultVariant(), defaultVariant)
-	variant := client.GetVariant("feature-name", WithVariantContext(context.Context{
-		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}))
+	variant := client.GetVariant("feature-name",
+		VariantOptions{Ctx: context.Context{
+			Properties: map[string]string{"custom-id": "custom-ctx"},
+		}})
 	assert.Equal("custom-variant", variant.Name)
 
-	variantFromResolver := client.GetVariant("feature-name", WithVariantContext(context.Context{
-		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}), WithVariantResolver(func(featureName string) *api.Feature {
-		if featureName == features[0].Name {
-			return &features[0]
-		} else {
-			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
-			return nil
-		}
-	}))
+	variantFromResolver := client.GetVariant("feature-name",
+		VariantOptions{Ctx: context.Context{
+			Properties: map[string]string{"custom-id": "custom-ctx"},
+		},
+			Resolver: func(featureName string) *api.Feature {
+				if featureName == features[0].Name {
+					return &features[0]
+				} else {
+					t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
+					return nil
+				}
+			},
+		})
 
 	assert.Equal("custom-variant", variantFromResolver.Name)
 
@@ -437,22 +441,25 @@ func TestClient_WithSegment(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	isEnabled := client.IsEnabled(feature, WithContext(context.Context{
+	isEnabled := client.IsEnabled(feature, FeatureOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}))
+	}})
 
 	assert.True(isEnabled)
 
-	isEnabledWithResolver := client.IsEnabled(feature, WithContext(context.Context{
-		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}), WithResolver(func(featureName string) *api.Feature {
-		if featureName == features[0].Name {
-			return &features[0]
-		} else {
-			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
-			return nil
-		}
-	}))
+	isEnabledWithResolver := client.IsEnabled(feature, FeatureOptions{
+		Ctx: context.Context{
+			Properties: map[string]string{"custom-id": "custom-ctx"},
+		},
+		Resolver: func(featureName string) *api.Feature {
+			if featureName == features[0].Name {
+				return &features[0]
+			} else {
+				t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
+				return nil
+			}
+		},
+	})
 
 	assert.True(isEnabledWithResolver)
 
@@ -516,22 +523,25 @@ func TestClient_WithNonExistingSegment(t *testing.T) {
 
 	client.WaitForReady()
 
-	isEnabled := client.IsEnabled(feature, WithContext(context.Context{
+	isEnabled := client.IsEnabled(feature, FeatureOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}))
+	}})
 
 	assert.False(isEnabled)
 
-	isEnabledWithResolver := client.IsEnabled(feature, WithContext(context.Context{
-		Properties: map[string]string{"custom-id": "custom-ctx"},
-	}), WithResolver(func(featureName string) *api.Feature {
-		if featureName == features[0].Name {
-			return &features[0]
-		} else {
-			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
-			return nil
-		}
-	}))
+	isEnabledWithResolver := client.IsEnabled(feature, FeatureOptions{
+		Ctx: context.Context{
+			Properties: map[string]string{"custom-id": "custom-ctx"},
+		},
+		Resolver: func(featureName string) *api.Feature {
+			if featureName == features[0].Name {
+				return &features[0]
+			} else {
+				t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
+				return nil
+			}
+		},
+	})
 
 	assert.False(isEnabledWithResolver)
 
@@ -619,22 +629,22 @@ func TestClient_WithMultipleSegments(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	isEnabled := client.IsEnabled(feature, WithContext(context.Context{
+	isEnabled := client.IsEnabled(feature, FeatureOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}))
+	}})
 
 	assert.True(isEnabled)
 
-	isEnabledWithResolver := client.IsEnabled(feature, WithContext(context.Context{
+	isEnabledWithResolver := client.IsEnabled(feature, FeatureOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}), WithResolver(func(featureName string) *api.Feature {
+	}, Resolver: func(featureName string) *api.Feature {
 		if featureName == features[0].Name {
 			return &features[0]
 		} else {
 			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
 			return nil
 		}
-	}))
+	}})
 
 	assert.True(isEnabledWithResolver)
 
@@ -734,24 +744,24 @@ func TestClient_VariantShouldRespectConstraint(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	variant := client.GetVariant(feature, WithVariantContext(context.Context{
+	variant := client.GetVariant(feature, VariantOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}))
+	}})
 
 	assert.True(variant.Enabled)
 
 	assert.True(variant.FeatureEnabled)
 
-	variantFromResolver := client.GetVariant(feature, WithVariantContext(context.Context{
+	variantFromResolver := client.GetVariant(feature, VariantOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}), WithVariantResolver(func(featureName string) *api.Feature {
+	}, Resolver: func(featureName string) *api.Feature {
 		if featureName == features[0].Name {
 			return &features[0]
 		} else {
 			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
 			return nil
 		}
-	}))
+	}})
 
 	assert.True(variantFromResolver.Enabled)
 
@@ -853,24 +863,24 @@ func TestClient_VariantShouldFailWhenSegmentConstraintsDontMatch(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	variant := client.GetVariant(feature, WithVariantContext(context.Context{
+	variant := client.GetVariant(feature, VariantOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}))
+	}})
 
 	assert.False(variant.Enabled)
 
 	assert.False(variant.FeatureEnabled)
 
-	variantFromResolver := client.GetVariant(feature, WithVariantContext(context.Context{
+	variantFromResolver := client.GetVariant(feature, VariantOptions{Ctx: context.Context{
 		Properties: map[string]string{"custom-id": "custom-ctx", "semver": "3.2.2", "age": "18", "domain": "unleashtest"},
-	}), WithVariantResolver(func(featureName string) *api.Feature {
+	}, Resolver: func(featureName string) *api.Feature {
 		if featureName == features[0].Name {
 			return &features[0]
 		} else {
 			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
 			return nil
 		}
-	}))
+	}})
 
 	assert.False(variantFromResolver.Enabled)
 
@@ -957,7 +967,7 @@ func TestClient_ShouldFavorStrategyVariantOverFeatureVariant(t *testing.T) {
 
 	client.WaitForReady()
 
-	strategyVariant := client.GetVariant("feature-x")
+	strategyVariant := client.GetVariant("feature-x", VariantOptions{})
 
 	assert.True(strategyVariant.Enabled)
 
@@ -1057,7 +1067,7 @@ func TestClient_ShouldReturnOldVariantForNonMatchingStrategyVariant(t *testing.T
 
 	client.WaitForReady()
 
-	strategyVariant := client.GetVariant("feature-x")
+	strategyVariant := client.GetVariant("feature-x", VariantOptions{})
 
 	assert.True(strategyVariant.Enabled)
 
@@ -1119,7 +1129,7 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 	assert.NoError(err)
 	client.WaitForReady()
 
-	variant := client.GetVariant(feature, WithVariantContext(context.Context{}))
+	variant := client.GetVariant(feature, VariantOptions{Ctx: context.Context{}})
 
 	assert.False(variant.Enabled)
 
@@ -1127,14 +1137,17 @@ func TestClient_VariantFromEnabledFeatureWithNoVariants(t *testing.T) {
 
 	assert.Equal(disabledVariantFeatureEnabled, variant)
 
-	variantFromResolver := client.GetVariant(feature, WithVariantContext(context.Context{}), WithVariantResolver(func(featureName string) *api.Feature {
-		if featureName == features[0].Name {
-			return &features[0]
-		} else {
-			t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
-			return nil
-		}
-	}))
+	variantFromResolver := client.GetVariant(feature, VariantOptions{
+		Ctx: context.Context{},
+		Resolver: func(featureName string) *api.Feature {
+			if featureName == features[0].Name {
+				return &features[0]
+			} else {
+				t.Fatalf("the feature name passed %s was not the expected one %s", featureName, features[0].Name)
+				return nil
+			}
+		},
+	})
 
 	assert.False(variantFromResolver.Enabled)
 
@@ -1194,7 +1207,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 		Name: "fallback-variant",
 	}
 
-	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+	variant := client.GetVariant(feature, VariantOptions{VariantFallback: &fallbackVariant})
 
 	assert.False(variant.Enabled)
 
@@ -1206,7 +1219,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDisabled(t *testing.T) {
 		return &fallbackVariant
 	}
 
-	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+	variantWithFallbackFunc := client.GetVariant(feature, VariantOptions{VariantFallbackFunc: fallbackFunc})
 
 	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
 
@@ -1262,7 +1275,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 		Name: "fallback-variant",
 	}
 
-	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+	variant := client.GetVariant(feature, VariantOptions{VariantFallback: &fallbackVariant})
 
 	assert.False(variant.Enabled)
 
@@ -1278,7 +1291,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureEnabledButNoVariants(t *testing
 		return &fallbackVariant
 	}
 
-	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+	variantWithFallbackFunc := client.GetVariant(feature, VariantOptions{VariantFallbackFunc: fallbackFunc})
 
 	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
 
@@ -1320,7 +1333,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 		Name: "fallback-variant",
 	}
 
-	variant := client.GetVariant(feature, WithVariantFallback(&fallbackVariant))
+	variant := client.GetVariant(feature, VariantOptions{VariantFallback: &fallbackVariant})
 
 	assert.False(variant.Enabled)
 
@@ -1332,7 +1345,7 @@ func TestGetVariantWithFallbackVariantWhenFeatureDoesntExist(t *testing.T) {
 		return &fallbackVariant
 	}
 
-	variantWithFallbackFunc := client.GetVariant(feature, WithVariantFallbackFunc(fallbackFunc))
+	variantWithFallbackFunc := client.GetVariant(feature, VariantOptions{VariantFallbackFunc: fallbackFunc})
 
 	assert.Equal(fallbackVariant, *variantWithFallbackFunc)
 
@@ -1407,12 +1420,11 @@ func TestGetVariant_FallbackVariantFeatureEnabledSettingIsLeftUnchanged(t *testi
 		FeatureEnabled: false,
 	}
 
-	variantForEnabledFeatureNoVariants := client.GetVariant(enabledFeatureNoVariants, WithVariantFallback(&fallbackVariantFeatureDisabled))
+	variantForEnabledFeatureNoVariants := client.GetVariant(enabledFeatureNoVariants, VariantOptions{VariantFallback: &fallbackVariantFeatureDisabled})
 
 	assert.False(variantForEnabledFeatureNoVariants.FeatureEnabled)
 
-	variantForDisabledFeature := client.GetVariant(disabledFeature, WithVariantFallback(&fallbackVariantFeatureEnabled))
-
+	variantForDisabledFeature := client.GetVariant(disabledFeature, VariantOptions{VariantFallback: &fallbackVariantFeatureEnabled})
 	assert.True(variantForDisabledFeature.FeatureEnabled)
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
@@ -1489,7 +1501,7 @@ func TestConnectionAndIntervalHeadersAndBody(t *testing.T) {
 
 	assert.NoError(err)
 
-	client.IsEnabled("foo")
+	client.IsEnabled("foo", FeatureOptions{})
 
 	time.Sleep(100 * time.Millisecond)
 	err = client.Close()

--- a/config.go
+++ b/config.go
@@ -156,77 +156,64 @@ func (o *configOption) IsStreamingMode() bool {
 // FeatureResolver represents a function to be called to resolve the feature instead of using the repository
 type FeatureResolver func(feature string) *api.Feature
 
-// WithResolver allows you to bypass the repository when resolving a feature name to its actual instance.
-func WithResolver(resolver FeatureResolver) FeatureOption {
-	return func(opts *featureOption) {
-		opts.resolver = resolver
-	}
-}
-
 // FallbackFunc represents a function to be called if the feature is not found.
 type FallbackFunc func(feature string, ctx *context.Context) bool
 
-type featureOption struct {
-	fallback     *bool
-	fallbackFunc FallbackFunc
-	ctx          *context.Context
-	resolver     FeatureResolver
-}
-
+// FeatureOptions controls how IsEnabled evaluates a feature toggle.
+//
+// Resolver:
+//   - If Resolver is non-nil, it is used to resolve the feature by name instead of the repository.
+//     This bypasses the normal resolution path and should no longer be necessary in v6.
+//     It exists for backwards compatibility and may be removed in a future release.
+//
+// Context:
+//   - If Ctx is non-nil, it is merged with the client's static context and used when
+//     evaluating strategies, segments, and constraints.
+//   - It's recommended to provide a context and set at least one of userId or sessionId
+//     to get stable rollout and stickiness behavior.
+//
+// Fallback behavior (when the feature cannot be resolved):
+//   - If FallbackFunc is non-nil, it is called and its result is returned.
+//   - Else if Fallback is non-nil, *Fallback is returned.
+//   - Else the result defaults to false.
 type FeatureOptions struct {
-	Ctx          context.Context
-	Fallback     *bool
+	// Ctx provides the base request context for evaluation. If nil, the client's static
+	// context is used.
+	Ctx context.Context
+
+	// Fallback is returned when the feature cannot be resolved and FallbackFunc is nil.
+	Fallback *bool
+
+	// FallbackFunc is called when the feature cannot be resolved. If set, it takes
+	// precedence over Fallback.
 	FallbackFunc FallbackFunc
-	Resolver     FeatureResolver
+
+	// Resolver bypasses repository lookup for resolving the feature by name.
+	Resolver FeatureResolver
 }
 
+// VariantOptions controls how GetVariant evaluates a feature's variant.
+//
+// Resolver:
+//   - If Resolver is non-nil, it is used to resolve the feature by name instead of the repository.
+//     This bypasses the normal resolution path and should no longer be necessary in v6.
+//     It exists for backwards compatibility and may be removed in a future release.
+//
+// Context:
+//   - If Ctx is non-nil, it is merged with the client's static context and used when
+//     evaluating strategies, segments, and constraints.
+//   - It's recommended to provide a context and set at least one of userId or sessionId
+//     to get stable rollout and stickiness behavior.
+//
+// Fallback behavior (when no variant can be resolved):
+//   - If VariantFallbackFunc is non-nil, it is called and its result is returned.
+//   - Else if VariantFallback is non-nil, *VariantFallback is returned.
+//   - Else a default disabled variant is returned.
 type VariantOptions struct {
 	Ctx                 context.Context
 	VariantFallback     *api.Variant
 	VariantFallbackFunc VariantFallbackFunc
 	Resolver            FeatureResolver
-}
-
-// FeatureOption provides options for querying if a feature is enabled or not.
-type FeatureOption func(*featureOption)
-
-// WithFallback specifies what the value should be if the feature toggle is not found on the
-// unleash service.
-func WithFallback(fallback bool) FeatureOption {
-	return func(opts *featureOption) {
-		opts.fallback = &fallback
-	}
-}
-
-// WithFallbackFunc specifies a fallback function to evaluate a feature
-// toggle in the event that it is not found on the service.
-func WithFallbackFunc(fallback FallbackFunc) FeatureOption {
-	return func(opts *featureOption) {
-		opts.fallbackFunc = fallback
-	}
-}
-
-// WithContext allows the user to provide a context that will be passed into the active strategy
-// for determining if a specified feature should be enabled or not.
-func WithContext(ctx context.Context) FeatureOption {
-	return func(opts *featureOption) {
-		opts.ctx = &ctx
-	}
-}
-
-// WithVariantContext specifies a context for the GetVariant
-// call
-func WithVariantContext(ctx context.Context) VariantOption {
-	return func(opts *variantOption) {
-		opts.ctx = &ctx
-	}
-}
-
-// WithVariantResolver allows you to bypass the repository when resolving a feature name to its actual instance.
-func WithVariantResolver(resolver FeatureResolver) VariantOption {
-	return func(opts *variantOption) {
-		opts.resolver = resolver
-	}
 }
 
 // VariantFallbackFunc represents a function to be called if the variant is not found.
@@ -237,39 +224,6 @@ type variantOption struct {
 	variantFallbackFunc VariantFallbackFunc
 	ctx                 *context.Context
 	resolver            FeatureResolver
-}
-
-// VariantOption provides options for querying if a variant is found or not.
-type VariantOption func(*variantOption)
-
-// WithVariantFallback specifies what the value should be if the
-// variant is not found on the unleash service. This could be because
-// the feature doesn't exist, because it is disabled, or because it
-// has no variants.
-//
-// If you specify a fallback variant, note that its `FeatureEnabled`
-// field will be set to whatever you pass in or `false` by default. In
-// other words, it will not reflect the feature's actual enabled
-// state.
-func WithVariantFallback(variantFallback *api.Variant) VariantOption {
-	return func(opts *variantOption) {
-		opts.variantFallback = variantFallback
-	}
-}
-
-// WithVariantFallbackFunc specifies a fallback function to evaluate
-// to a variant when a variant is not found for a feature. This could
-// be because the feature doesn't exist, because it is disabled, or
-// because it has no variants.
-//
-// If you specify a fallback variant, note that its `FeatureEnabled`
-// field will be set to whatever you pass in or `false` by default. In
-// other words, it will not reflect the feature's actual enabled
-// state.
-func WithVariantFallbackFunc(variantFallbackFunc VariantFallbackFunc) VariantOption {
-	return func(opts *variantOption) {
-		opts.variantFallbackFunc = variantFallbackFunc
-	}
 }
 
 type repositoryOptions struct {

--- a/config.go
+++ b/config.go
@@ -173,6 +173,17 @@ type featureOption struct {
 	resolver     FeatureResolver
 }
 
+type FeatureOptions struct {
+	Ctx    context.Context
+	HasCtx bool
+
+	Fallback    bool
+	HasFallback bool
+
+	FallbackFunc FallbackFunc
+	Resolver     FeatureResolver
+}
+
 // FeatureOption provides options for querying if a feature is enabled or not.
 type FeatureOption func(*featureOption)
 

--- a/config.go
+++ b/config.go
@@ -174,14 +174,17 @@ type featureOption struct {
 }
 
 type FeatureOptions struct {
-	Ctx    context.Context
-	HasCtx bool
-
-	Fallback    bool
-	HasFallback bool
-
+	Ctx          context.Context
+	Fallback     *bool
 	FallbackFunc FallbackFunc
 	Resolver     FeatureResolver
+}
+
+type VariantOptions struct {
+	Ctx                 context.Context
+	VariantFallback     *api.Variant
+	VariantFallbackFunc VariantFallbackFunc
+	Resolver            FeatureResolver
 }
 
 // FeatureOption provides options for querying if a feature is enabled or not.

--- a/example_bootstrap_from_file_test.go
+++ b/example_bootstrap_from_file_test.go
@@ -48,7 +48,7 @@ func Test_bootstrapFromFile(t *testing.T) {
 		t.Fail()
 	}
 
-	enabled := unleash.IsEnabled("DateExample", unleash.WithContext(context.Context{}))
+	enabled := unleash.IsEnabled("DateExample", unleash.FeatureOptions{Ctx: context.Context{}})
 	a.True(enabled)
 	err = unleash.Close()
 	a.Nil(err)

--- a/example_custom_strategy_test.go
+++ b/example_custom_strategy_test.go
@@ -55,7 +55,7 @@ func Example_customStrategy() {
 
 	for {
 		<-timer.C
-		enabled := unleash.IsEnabled("unleash.me", unleash.WithContext(ctx))
+		enabled := unleash.IsEnabled("unleash.me", unleash.FeatureOptions{Ctx: ctx})
 		fmt.Printf("feature is enabled? %v\n", enabled)
 		timer.Reset(1 * time.Second)
 	}

--- a/example_fallback_func_test.go
+++ b/example_fallback_func_test.go
@@ -26,7 +26,7 @@ func Example_fallbackFunc() {
 
 	for {
 		<-timer.C
-		isEnabled := unleash.IsEnabled(MissingFeature, unleash.WithFallbackFunc(fallback))
+		isEnabled := unleash.IsEnabled(MissingFeature, unleash.FeatureOptions{FallbackFunc: fallback})
 		fmt.Printf("'%s' enabled? %v\n", PropertyName, isEnabled)
 		timer.Reset(1 * time.Second)
 	}

--- a/example_simple_usage_test.go
+++ b/example_simple_usage_test.go
@@ -21,7 +21,7 @@ func Example_simpleUsage() {
 
 	for {
 		<-timer.C
-		fmt.Printf("'%s' enabled? %v\n", PropertyName, unleash.IsEnabled(PropertyName))
+		fmt.Printf("'%s' enabled? %v\n", PropertyName, unleash.IsEnabled(PropertyName, unleash.FeatureOptions{}))
 		timer.Reset(1 * time.Second)
 	}
 

--- a/example_with_instance_test.go
+++ b/example_with_instance_test.go
@@ -28,7 +28,7 @@ func Sync(client *unleash.Client) {
 		case ie := <-client.Impression():
 			fmt.Printf("IMPRESSION: %+v\n", ie)
 		case <-timer.C:
-			fmt.Printf("ISENABLED: %v\n", client.IsEnabled("eid.enabled"))
+			fmt.Printf("ISENABLED: %v\n", client.IsEnabled("eid.enabled", unleash.FeatureOptions{}))
 			timer.Reset(1 * time.Second)
 		}
 	}

--- a/impression_test.go
+++ b/impression_test.go
@@ -62,7 +62,7 @@ func TestImpression_Off(t *testing.T) {
 	mockListener.On("OnImpression", mock.Anything).Maybe()
 
 	client := setupClient(t, mockListener)
-	client.IsEnabled(feature)
+	client.IsEnabled(feature, FeatureOptions{})
 
 	assert.NoError(client.Close())
 	mockListener.AssertNotCalled(t, "OnImpression", mock.Anything)
@@ -118,7 +118,7 @@ func TestImpression_IsEnabled(t *testing.T) {
 	}).Once()
 
 	client := setupClient(t, mockListener)
-	client.IsEnabled(feature)
+	client.IsEnabled(feature, FeatureOptions{})
 
 	wg.Wait()
 	assert.NoError(client.Close())
@@ -190,7 +190,7 @@ func TestImpression_GetVariant(t *testing.T) {
 	}).Once()
 
 	client := setupClient(t, mockListener)
-	client.GetVariant(feature)
+	client.GetVariant(feature, VariantOptions{})
 
 	wg.Wait()
 	assert.NoError(client.Close())
@@ -270,7 +270,7 @@ func TestImpression_WithContext(t *testing.T) {
 	}).Once()
 
 	client := setupClient(t, mockListener)
-	client.IsEnabled(feature, WithContext(userCtx))
+	client.IsEnabled(feature, FeatureOptions{Ctx: userCtx})
 
 	wg.Wait()
 	assert.NoError(client.Close())
@@ -361,10 +361,10 @@ func TestImpression_WithContextAndMultipleEvents(t *testing.T) {
 
 	client := setupClient(t, mockListener)
 
-	resultWithCtx := client.IsEnabled(feature, WithContext(userCtx))
+	resultWithCtx := client.IsEnabled(feature, FeatureOptions{Ctx: userCtx})
 	assert.True(resultWithCtx)
 
-	resultWithoutCtx := client.IsEnabled(feature)
+	resultWithoutCtx := client.IsEnabled(feature, FeatureOptions{})
 	assert.False(resultWithoutCtx)
 
 	wg.Wait()
@@ -433,7 +433,7 @@ func TestImpression_GetChannelMethod(t *testing.T) {
 	}()
 
 	<-ready
-	client.IsEnabled(feature)
+	client.IsEnabled(feature, FeatureOptions{})
 
 	wg.Wait()
 	assert.NoError(client.Close())

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -87,7 +87,7 @@ func TestMetrics_VariantsCountToggles(t *testing.T) {
 	)
 
 	client.WaitForReady()
-	client.GetVariant("foo")
+	client.GetVariant("foo", VariantOptions{})
 
 	registered_metric, ok := client.metrics.counters.Load("foo")
 	assert.True(ok, "should have a count for 'foo'")
@@ -164,9 +164,9 @@ func TestMetrics_DisabledMetrics(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 
 	client.WaitForReady()
-	client.IsEnabled("foo")
-	client.IsEnabled("bar")
-	client.IsEnabled("baz")
+	client.IsEnabled("foo", FeatureOptions{})
+	client.IsEnabled("bar", FeatureOptions{})
+	client.IsEnabled("baz", FeatureOptions{})
 
 	time.Sleep(300 * time.Millisecond)
 	client.Close()
@@ -338,7 +338,7 @@ func TestMetrics_ShouldNotCountMetricsForParentToggles(t *testing.T) {
 	)
 	assert.Nil(err, "client should not return an error")
 	client.WaitForReady()
-	client.IsEnabled("child")
+	client.IsEnabled("child", FeatureOptions{})
 
 	child_metric, ok := client.metrics.counters.Load("child")
 	assert.True(ok, "should have a count for 'child'")
@@ -389,9 +389,9 @@ func TestMetrics_ShouldBackoffOn500(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 
 	client.WaitForReady()
-	client.IsEnabled("foo")
-	client.IsEnabled("bar")
-	client.IsEnabled("baz")
+	client.IsEnabled("foo", FeatureOptions{})
+	client.IsEnabled("bar", FeatureOptions{})
+	client.IsEnabled("baz", FeatureOptions{})
 
 	time.Sleep(320 * time.Millisecond)
 	err = client.Close()
@@ -429,11 +429,11 @@ func TestMetrics_ErrorCountShouldDecreaseIfSuccessful(t *testing.T) {
 	assert.Nil(err, "client should not return an error")
 
 	client.WaitForReady()
-	client.IsEnabled("foo")
-	client.IsEnabled("bar")
-	client.IsEnabled("baz")
+	client.IsEnabled("foo", FeatureOptions{})
+	client.IsEnabled("bar", FeatureOptions{})
+	client.IsEnabled("baz", FeatureOptions{})
 	time.Sleep(360 * time.Millisecond)
-	client.IsEnabled("foo")
+	client.IsEnabled("foo", FeatureOptions{})
 	time.Sleep(100 * time.Millisecond)
 	err = client.Close()
 	assert.Equal(float64(0), client.metrics.errors)
@@ -591,9 +591,9 @@ func TestMetrics_metricsData_includes_new_metadata(t *testing.T) {
 	assert.Nil(err, "Client should open without a problem")
 
 	client.WaitForReady()
-	client.IsEnabled("foo")
-	client.IsEnabled("bar")
-	client.IsEnabled("baz")
+	client.IsEnabled("foo", FeatureOptions{})
+	client.IsEnabled("bar", FeatureOptions{})
+	client.IsEnabled("baz", FeatureOptions{})
 
 	time.Sleep(320 * time.Millisecond)
 	err = client.Close()

--- a/nooplistener_test.go
+++ b/nooplistener_test.go
@@ -17,7 +17,8 @@ func Test_defaultsToNoopListener(t *testing.T) {
 	if result != nil {
 		t.Fail()
 	}
-	res := IsEnabled("test", WithFallback(false))
+	fallback := false
+	res := IsEnabled("test", FeatureOptions{Fallback: &fallback})
 	assert.Equal(t, false, res)
 
 	assert.IsType(t, &NoopListener{}, defaultClient.errorListener)

--- a/spec_test.go
+++ b/spec_test.go
@@ -69,7 +69,7 @@ func (tc TestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.IsEnabled(tc.ToggleName, WithContext(tc.Context))
+			client.IsEnabledWithOptions(tc.ToggleName, FeatureOptions{Ctx: tc.Context})
 			wg.Done()
 		}()
 		result := client.IsEnabled(tc.ToggleName, WithContext(tc.Context))
@@ -91,10 +91,10 @@ func (vtc VariantTestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.GetVariant(vtc.ToggleName, WithVariantContext(vtc.Context))
+			client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 			wg.Done()
 		}()
-		result := client.GetVariant(vtc.ToggleName, WithVariantContext(vtc.Context))
+		result := client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 		wg.Wait()
 		assert.Equal(t, vtc.ExpectedResult.Enabled, result.Enabled)
 		// copy over the FeatureEnabled field with different JSON tag

--- a/spec_test.go
+++ b/spec_test.go
@@ -69,10 +69,10 @@ func (tc TestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.IsEnabledWithOptions(tc.ToggleName, FeatureOptions{Ctx: tc.Context})
+			client.IsEnabled(tc.ToggleName, FeatureOptions{Ctx: tc.Context})
 			wg.Done()
 		}()
-		result := client.IsEnabled(tc.ToggleName, WithContext(tc.Context))
+		result := client.IsEnabled(tc.ToggleName, FeatureOptions{Ctx: tc.Context})
 		wg.Wait()
 		assert.Equal(t, tc.ExpectedResult, result)
 	}
@@ -91,10 +91,10 @@ func (vtc VariantTestCase) RunWithClient(client *Client) func(*testing.T) {
 		go func() {
 			// Call IsEnabled concurrently with itself to catch
 			// potential data races with go test -race.
-			client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
+			client.GetVariant(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 			wg.Done()
 		}()
-		result := client.GetVariantWithOptions(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
+		result := client.GetVariant(vtc.ToggleName, VariantOptions{Ctx: vtc.Context})
 		wg.Wait()
 		assert.Equal(t, vtc.ExpectedResult.Enabled, result.Enabled)
 		// copy over the FeatureEnabled field with different JSON tag

--- a/streaming_integration_test.go
+++ b/streaming_integration_test.go
@@ -92,10 +92,10 @@ func TestStreamingMode_UnleashConnectedEvent(t *testing.T) {
 	client.WaitForReady()
 
 	// Verify the feature is enabled after hydration
-	assert.True(t, client.IsEnabled("test-feature"), "test-feature should be enabled after hydration")
+	assert.True(t, client.IsEnabled("test-feature", FeatureOptions{}), "test-feature should be enabled after hydration")
 
 	// Test with a non-existent feature
-	assert.False(t, client.IsEnabled("non-existent-feature"), "non-existent-feature should be disabled")
+	assert.False(t, client.IsEnabled("non-existent-feature", FeatureOptions{}), "non-existent-feature should be disabled")
 }
 
 // TestStreamingMode_UnleashUpdatedEvent tests processing of a simple unleash-updated event
@@ -128,7 +128,7 @@ func TestStreamingMode_UnleashUpdatedEvent(t *testing.T) {
 	client.WaitForReady()
 
 	// Feature should initially be disabled
-	assert.False(t, client.IsEnabled("feature-1"), "feature-1 should be initially disabled")
+	assert.False(t, client.IsEnabled("feature-1", FeatureOptions{}), "feature-1 should be initially disabled")
 
 	// Wait for the update event to be processed
 	select {
@@ -139,5 +139,5 @@ func TestStreamingMode_UnleashUpdatedEvent(t *testing.T) {
 	}
 
 	// Feature should now be enabled after update
-	assert.True(t, client.IsEnabled("feature-1"), "feature-1 should be enabled after update")
+	assert.True(t, client.IsEnabled("feature-1", FeatureOptions{}), "feature-1 should be enabled after update")
 }

--- a/unleash.go
+++ b/unleash.go
@@ -47,15 +47,11 @@ type ImpressionListener interface {
 }
 
 // IsEnabled queries the default client whether or not the specified feature is enabled or not.
-func IsEnabled(feature string, options ...FeatureOption) bool {
+func IsEnabled(feature string, options FeatureOptions) bool {
 	if defaultClient == nil {
-		var opts featureOption
-		for _, o := range options {
-			o(&opts)
-		}
-		return handleFallback(opts, feature, opts.ctx).Enabled
+		return handleFallback(options.FallbackFunc, options.Fallback, feature, &options.Ctx).Enabled
 	}
-	return defaultClient.IsEnabled(feature, options...)
+	return defaultClient.IsEnabled(feature, options)
 }
 
 // Initialize will specify the options to be used by the default client.
@@ -64,11 +60,11 @@ func Initialize(options ...ConfigOption) (err error) {
 	return err
 }
 
-func GetVariant(feature string, options ...VariantOption) *api.Variant {
+func GetVariant(feature string, options VariantOptions) *api.Variant {
 	if defaultClient == nil {
 		return api.GetDefaultVariant()
 	}
-	return defaultClient.GetVariant(feature, options...)
+	return defaultClient.GetVariant(feature, options)
 }
 
 // Close will close the default client.

--- a/unleash_test.go
+++ b/unleash_test.go
@@ -48,7 +48,7 @@ func Test_withVariants(t *testing.T) {
 		t.Fail()
 	}
 
-	variant := unleash.GetVariant("Demo")
+	variant := unleash.GetVariant("Demo", unleash.VariantOptions{})
 	if variant.Enabled == false {
 		t.Fatalf("Expected variant to be enabled")
 	}
@@ -107,7 +107,7 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 		t.Fail()
 	}
 
-	feature := unleash.GetVariant("AuditLog")
+	feature := unleash.GetVariant("AuditLog", unleash.VariantOptions{})
 	if feature.Enabled == true {
 		t.Fatalf("Expected feature to be disabled because Environment does not exist as strategy")
 	}
@@ -116,7 +116,8 @@ func Test_withVariantsAndANonExistingStrategyName(t *testing.T) {
 }
 
 func Test_IsEnabledWithUninitializedClient(t *testing.T) {
-	result := unleash.IsEnabled("foo", unleash.WithFallback(true))
+	fallback := true
+	result := unleash.IsEnabled("foo", unleash.FeatureOptions{Fallback: &fallback})
 	if !result {
 		t.Fatalf("Expected true")
 	}


### PR DESCRIPTION
Drops the old IsEnabled functions that required the functional interface and swapped in IsEnabledWithOptions.

I don't really want to support the old methods if they're going to cause so many performance problems so we're doing a hard break here

Most of this is patching tests. The important work got did in #221 