### PR TITLE
fix: always send empty variant buckets if not present

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -233,8 +233,9 @@ func (m *metrics) buildBucketAndReset(lastCloseTime time.Time) (api.Bucket, bool
 		}
 
 		toggleCounters := api.ToggleCount{
-			Yes: int32(yes),
-			No:  int32(no),
+			Yes:      int32(yes),
+			No:       int32(no),
+			Variants: map[string]int32{},
 		}
 
 		// we can have a little locking, as a treat. Variants are likely a luke warm path at best

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -635,3 +635,27 @@ func TestReinsertingBucketsAlsoRestoresVariants(t *testing.T) {
 
 	assert.EqualValues(t, 1, registered_metric.(*toggleCounters).variants["some-variant"])
 }
+
+func TestMetrics_NotCountingVariantsStillIncludesEmptyVariantBucket(t *testing.T) {
+	metrics_handler := &metrics{
+		metricsChannels: metricsChannels{
+			count: make(chan metric, 1),
+		},
+	}
+
+	metrics_handler.count("some-feature", true)
+	retrieved_bucket, ok := metrics_handler.buildBucketAndReset(time.Now())
+	if !ok {
+		t.Fatal("Missing bucket for 'some-feature'")
+	}
+
+	toggle := retrieved_bucket.Toggles["some-feature"]
+	assert.NotNil(t, toggle.Variants)
+	assert.Equal(t, 0, len(toggle.Variants))
+
+	raw, err := json.Marshal(retrieved_bucket)
+	if err != nil {
+		t.Fatalf("failed to marshal bucket: %v", err)
+	}
+	assert.Contains(t, string(raw), "\"variants\":{}")
+}


### PR DESCRIPTION
Unleash expects empty variants lists not nil for whatever reason. V6 changed the internal behavior here to send nils if not present. This patches that to include empties instead.

Fixes #232 

Related to https://github.com/Unleash/unleash/pull/11296