### PR TITLE
feat: implement basic regex constraint

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -16,7 +16,7 @@ jobs:
         name: Checkout client specifications
         with:
           repository: Unleash/client-specification
-          ref: refs/tags/v5.1.0
+          ref: refs/tags/v6.0.1
           path: testdata/client-specification
       - uses: actions/setup-go@v2
         name: Setup go

--- a/api/constraint.go
+++ b/api/constraint.go
@@ -63,6 +63,10 @@ const (
 	// OperatorSemverGt indicates that the context value
 	// must be greater than the specified SemVer version.
 	OperatorSemverGt Operator = "SEMVER_GT"
+
+	// OperatorRegex indicates that the context value
+	// must match the specified regular expression.
+	OperatorRegex Operator = "REGEX"
 )
 
 // Constraint represents a constraint on a particular context value.

--- a/internal/constraints/check.go
+++ b/internal/constraints/check.go
@@ -62,6 +62,8 @@ func checkConstraint(ctx *context.Context, constraint api.Constraint) (bool, err
 		return operatorSemverLt(ctx, constraint)
 	case api.OperatorSemverGt:
 		return operatorSemverGt(ctx, constraint)
+	case api.OperatorRegex:
+		return operatorRegex(ctx, constraint), nil
 	default:
 		return false, fmt.Errorf("unknown constraint operator: %s", constraint.Operator)
 	}

--- a/internal/constraints/operator_regex.go
+++ b/internal/constraints/operator_regex.go
@@ -1,0 +1,24 @@
+package constraints
+
+import (
+	"regexp"
+
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+)
+
+func operatorRegex(ctx *context.Context, constraint api.Constraint) bool {
+	contextValue := ctx.Field(constraint.ContextName)
+
+	pattern := constraint.Value
+	if constraint.CaseInsensitive {
+		pattern = "(?i:" + pattern + ")"
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+
+	return re.MatchString(contextValue)
+}

--- a/internal/constraints/operator_regex_test.go
+++ b/internal/constraints/operator_regex_test.go
@@ -1,0 +1,47 @@
+package constraints
+
+import (
+	"testing"
+
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+	"github.com/Unleash/unleash-go-sdk/v6/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOperatorRegex(t *testing.T) {
+	testCases := []checkTestCase{
+		{
+			ctx:         &context.Context{Properties: map[string]string{"email": "example@getunleash.ai"}},
+			constraints: []api.Constraint{{ContextName: "email", Operator: "REGEX", Value: ".*@getunleash\\.ai$"}},
+			expected:    true,
+		},
+		{
+			ctx:         &context.Context{Properties: map[string]string{"email": "example@getunleash.ai"}},
+			constraints: []api.Constraint{{ContextName: "email", Operator: "REGEX", Value: "["}},
+			expected:    false,
+		},
+		{
+			ctx:         &context.Context{Properties: map[string]string{"email": "example@getunleash.ai"}},
+			constraints: []api.Constraint{{ContextName: "email", Operator: "REGEX", Value: "/.*@getunleash\\.ai$/i"}},
+			expected:    false,
+		},
+		{
+			ctx:         &context.Context{Properties: map[string]string{}},
+			constraints: []api.Constraint{{ContextName: "userId", Operator: "REGEX", Value: "\\d+"}},
+			expected:    false,
+		},
+		{
+			ctx:         &context.Context{Properties: map[string]string{"email": "EXAMPLE@GETUNLEASH.AI"}},
+			constraints: []api.Constraint{{ContextName: "email", Operator: "REGEX", Value: ".*@getunleash\\.ai$", CaseInsensitive: true}},
+			expected:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if ok, err := Check(tc.ctx, tc.constraints); err != nil {
+			t.Fatal(err)
+		} else {
+			assert.Equal(t, tc.expected, ok)
+		}
+	}
+}


### PR DESCRIPTION
Basic regex constraint. This is path is a bit expensive and wants some caching. We don't have the prepass compile pattern that the RustSDK/Yggdasil have so I'm planning on slapping an LRU cache on this and moving on with my life -> next PR