### PR TITLE
chore: CI maintenance

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.21, 1.22, 1.23, 1.24]
+        version: [1.21, 1.22, 1.23, 1.24, 1.25, 1.26]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         name: Checkout code
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         name: Checkout client specifications
         with:
           repository: Unleash/client-specification
           ref: refs/tags/v5.1.0
           path: testdata/client-specification
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v6
         name: Setup go
         with:
           go-version: ${{ matrix.version }}
@@ -32,6 +32,7 @@ jobs:
           go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - name: Run spec tests
+          set -euo pipefail
         run: go test -json ./... -tags='norace' | gotestfmt
       - name: Run all tests with race detection
         timeout-minutes: 1
@@ -40,6 +41,7 @@ jobs:
           go test -json -race -covermode=atomic -coverprofile=profile.cov ./... -tags='!norace' | gotestfmt
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
+        continue-on-error: true
         with:
           path-to-profile: profile.cov
           flag-name: Go-${{ matrix.version }}
@@ -49,5 +51,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: shogo82148/actions-goveralls@v1
+        continue-on-error: true
         with:
           parallel-finished: true

--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -19,7 +19,7 @@ jobs:
           repository: Unleash/client-specification
           ref: refs/tags/v5.1.0
           path: testdata/client-specification
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v5
         name: Setup go
         with:
           go-version: ${{ matrix.version }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can use this client with [Unleash Enterprise](https://www.getunleash.io/pric
 
 ## Go Version
 
-The client is currently tested against Go 1.21.x, 1.22.x, 1.23.x and 1.24.x. These versions will be updated
+The client is currently tested against Go 1.21.x, 1.22.x, 1.23.x, 1.24.x, 1.25.x and 1.26.x. These versions will be updated
 as new versions of Go are released.
 
 The client may work on older versions of Go as well, but is not actively tested.


### PR DESCRIPTION
Bit of CI clean up

- make coveralls upload optional so coveralls outages don't block release
- update some actions to latest
- bump supported Go versions to latest