### PR TITLE
fix: uncurse impact metrics api

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,10 +44,10 @@ var disabledVariantFeatureEnabled = &api.Variant{
 // Client is a structure representing an API client of an Unleash server.
 type Client struct {
 	errorChannels
-	options            configOption
-	repository         *repository
-	metrics            *metrics
-	impactMetrics      *impactmetrics.MetricsAPI
+	options    configOption
+	repository *repository
+	metrics    *metrics
+	*impactmetrics.MetricsAPI
 	strategies         []strategy.Strategy
 	errorListener      ErrorListener
 	metricsListener    MetricListener
@@ -232,7 +232,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 			warnings: errChannels.warnings,
 		},
 	)
-	uc.impactMetrics = impactMetricsAPI
+	uc.MetricsAPI = impactMetricsAPI
 
 	uc.metrics = newMetrics(
 		metricsOptions{
@@ -436,37 +436,7 @@ func (uc *Client) getVariant(feature string, snapshot *FeatureMemoryState, opts 
 
 // Deprecated: Use impact metrics methods directly on the client instead.
 func (uc *Client) ImpactMetrics() *impactmetrics.MetricsAPI {
-	return uc.impactMetrics
-}
-
-// DefineCounter registers a counter metric for impact metrics reporting.
-func (uc *Client) DefineCounter(name, help string) {
-	uc.impactMetrics.DefineCounter(name, help)
-}
-
-// IncrementCounter increments a previously defined counter metric by 1.
-func (uc *Client) IncrementCounter(name string) {
-	uc.impactMetrics.IncrementCounter(name)
-}
-
-// DefineGauge registers a gauge metric for impact metrics reporting.
-func (uc *Client) DefineGauge(name, help string) {
-	uc.impactMetrics.DefineGauge(name, help)
-}
-
-// UpdateGauge updates the value for a previously defined gauge metric.
-func (uc *Client) UpdateGauge(name string, value float64) {
-	uc.impactMetrics.UpdateGauge(name, value)
-}
-
-// DefineHistogram registers a histogram metric for impact metrics reporting.
-func (uc *Client) DefineHistogram(name, help string, buckets ...float64) {
-	uc.impactMetrics.DefineHistogram(name, help, buckets...)
-}
-
-// ObserveHistogram records a value in a previously defined histogram metric.
-func (uc *Client) ObserveHistogram(name string, value float64) {
-	uc.impactMetrics.ObserveHistogram(name, value)
+	return uc.MetricsAPI
 }
 
 // Close stops the client from syncing data from the server.

--- a/client.go
+++ b/client.go
@@ -434,8 +434,39 @@ func (uc *Client) getVariant(feature string, snapshot *FeatureMemoryState, opts 
 	}.GetVariant(ctx, nil)
 }
 
+// Deprecated: Use impact metrics methods directly on the client instead.
 func (uc *Client) ImpactMetrics() *impactmetrics.MetricsAPI {
 	return uc.impactMetrics
+}
+
+// DefineCounter registers a counter metric for impact metrics reporting.
+func (uc *Client) DefineCounter(name, help string) {
+	uc.impactMetrics.DefineCounter(name, help)
+}
+
+// IncrementCounter increments a previously defined counter metric by 1.
+func (uc *Client) IncrementCounter(name string) {
+	uc.impactMetrics.IncrementCounter(name)
+}
+
+// DefineGauge registers a gauge metric for impact metrics reporting.
+func (uc *Client) DefineGauge(name, help string) {
+	uc.impactMetrics.DefineGauge(name, help)
+}
+
+// UpdateGauge updates the value for a previously defined gauge metric.
+func (uc *Client) UpdateGauge(name string, value float64) {
+	uc.impactMetrics.UpdateGauge(name, value)
+}
+
+// DefineHistogram registers a histogram metric for impact metrics reporting.
+func (uc *Client) DefineHistogram(name, help string, buckets ...float64) {
+	uc.impactMetrics.DefineHistogram(name, help, buckets...)
+}
+
+// ObserveHistogram records a value in a previously defined histogram metric.
+func (uc *Client) ObserveHistogram(name string, value float64) {
+	uc.impactMetrics.ObserveHistogram(name, value)
 }
 
 // Close stops the client from syncing data from the server.

--- a/unleash.go
+++ b/unleash.go
@@ -79,3 +79,51 @@ func Close() error {
 func WaitForReady() {
 	defaultClient.WaitForReady()
 }
+
+// DefineCounter registers a counter metric for impact metrics reporting.
+func DefineCounter(name, help string) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().DefineCounter(name, help)
+}
+
+// IncrementCounter increments a previously defined counter metric.
+func IncrementCounter(name string) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().IncrementCounter(name)
+}
+
+// DefineGauge registers a gauge metric for impact metrics reporting.
+func DefineGauge(name, help string) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().DefineGauge(name, help)
+}
+
+// UpdateGauge updates the value for a previously defined gauge metric.
+func UpdateGauge(name string, value float64) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().UpdateGauge(name, value)
+}
+
+// DefineHistogram registers a histogram metric for impact metrics reporting.
+func DefineHistogram(name, help string, buckets ...float64) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().DefineHistogram(name, help, buckets...)
+}
+
+// ObserveHistogram records a value in a previously defined histogram metric.
+func ObserveHistogram(name string, value float64) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.ImpactMetrics().ObserveHistogram(name, value)
+}

--- a/unleash.go
+++ b/unleash.go
@@ -85,7 +85,7 @@ func DefineCounter(name, help string) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().DefineCounter(name, help)
+	defaultClient.DefineCounter(name, help)
 }
 
 // IncrementCounter increments a previously defined counter metric.
@@ -93,7 +93,7 @@ func IncrementCounter(name string) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().IncrementCounter(name)
+	defaultClient.IncrementCounter(name)
 }
 
 // DefineGauge registers a gauge metric for impact metrics reporting.
@@ -101,7 +101,7 @@ func DefineGauge(name, help string) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().DefineGauge(name, help)
+	defaultClient.DefineGauge(name, help)
 }
 
 // UpdateGauge updates the value for a previously defined gauge metric.
@@ -109,7 +109,7 @@ func UpdateGauge(name string, value float64) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().UpdateGauge(name, value)
+	defaultClient.UpdateGauge(name, value)
 }
 
 // DefineHistogram registers a histogram metric for impact metrics reporting.
@@ -117,7 +117,7 @@ func DefineHistogram(name, help string, buckets ...float64) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().DefineHistogram(name, help, buckets...)
+	defaultClient.DefineHistogram(name, help, buckets...)
 }
 
 // ObserveHistogram records a value in a previously defined histogram metric.
@@ -125,5 +125,5 @@ func ObserveHistogram(name string, value float64) {
 	if defaultClient == nil {
 		return
 	}
-	defaultClient.ImpactMetrics().ObserveHistogram(name, value)
+	defaultClient.ObserveHistogram(name, value)
 }

--- a/unleash.go
+++ b/unleash.go
@@ -96,6 +96,14 @@ func IncrementCounter(name string) {
 	defaultClient.IncrementCounter(name)
 }
 
+// IncrementCounterBy increments a previously defined counter metric by a specified value.
+func IncrementCounterBy(name string, value int64) {
+	if defaultClient == nil {
+		return
+	}
+	defaultClient.IncrementCounterBy(name, value)
+}
+
 // DefineGauge registers a gauge metric for impact metrics reporting.
 func DefineGauge(name, help string) {
 	if defaultClient == nil {


### PR DESCRIPTION
API in it's existing state is a bit cursed. First it doesn't expose the impact metrics API in the top level client - that's actually the correct way to use this SDK for most use cases so we need to do that. Second, struct embedding is a first class feature in Go, we should just use it

Touches public API though so needs a deprecation notice + backwards compat