### PR TITLE
chore: trim ci versions to reality

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.21, 1.22, 1.23, 1.24, 1.25, 1.26]
+        version: [1.23, 1.24, 1.25, 1.26]
     steps:
       - uses: actions/checkout@v6
         name: Checkout code


### PR DESCRIPTION
This PR #201 has pinned us to 1.23 and above. As of Go 1.21, the version specified in go.mod is no longer a hint, it's a requirement. The way our CI runs at the moment will allow for on the fly toolchain upgrades, so 1.21, 1.22 and 1.23 are all practically running on Go version 1.23