### PR TITLE
feat: introduce adaptiveFetcher so we can include failover in streaming

### DIFF
--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -1,0 +1,151 @@
+package unleash
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// This exists purely because atomics must contain a single concrete type
+// we want to be able to both switch fetcher types and avoid mutexes so this
+// leaves us with this sad little container struct. Don't "fix" this
+type fetchContainer struct {
+	f togglerFetcher
+}
+
+type fetcherFactory struct {
+	newStreaming func(fetcherOptions, fetcherChannels) togglerFetcher
+	newPolling   func(fetcherOptions, fetcherChannels) togglerFetcher
+}
+
+func defaultFetcherFactory() fetcherFactory {
+	return fetcherFactory{
+		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return newStreamingFetcher(options, channels)
+		},
+		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return newPollingFetcher(options, channels)
+		},
+	}
+}
+
+type adaptiveFetcher struct {
+	currentFetcher atomic.Pointer[fetchContainer]
+	baseOptions    fetcherOptions
+	baseChannels   fetcherChannels
+	internalReady  chan bool
+	internalUpdate chan bool
+	ready          atomic.Bool
+	started        bool
+	stopped        bool
+	ctx            context.Context
+	cancel         context.CancelFunc
+	mu             sync.Mutex
+	factory        fetcherFactory
+}
+
+func newAdaptiveFetcher(options fetcherOptions, channels fetcherChannels) *adaptiveFetcher {
+	return newAdaptiveFetcherWithFactory(options, channels, defaultFetcherFactory())
+}
+
+// If you're considering using this in production code, probably don't. This is exposed
+// internally so that test code has a seam to inject fake fetchers and control the lifecycle.
+// Prefer using newAdaptiveFetcher, which will construct appropriate fetchers for
+// real world usage
+func newAdaptiveFetcherWithFactory(
+	options fetcherOptions,
+	channels fetcherChannels,
+	factory fetcherFactory,
+) *adaptiveFetcher {
+	ir := make(chan bool, 1)
+	iu := make(chan bool, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	af := &adaptiveFetcher{
+		baseOptions:    options,
+		baseChannels:   channels,
+		internalReady:  ir,
+		internalUpdate: iu,
+		ctx:            ctx,
+		cancel:         cancel,
+		factory:        factory,
+	}
+
+	initial := af.factory.newStreaming(options, fetcherChannels{
+		ready:         ir,
+		update:        iu,
+		errorChannels: channels.errorChannels,
+	})
+
+	af.currentFetcher.Store(&fetchContainer{f: initial})
+
+	return af
+}
+
+func (af *adaptiveFetcher) superviseFetchers() {
+	for {
+		select {
+		case <-af.internalReady:
+			if af.ready.CompareAndSwap(false, true) {
+				af.baseChannels.ready <- true
+			}
+		case <-af.internalUpdate:
+			af.baseChannels.update <- true
+		case <-af.ctx.Done():
+			return
+		}
+	}
+}
+
+func (af *adaptiveFetcher) cutover() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.stopped {
+		return
+	}
+
+	current := af.currentFetcher.Load().f
+
+	if _, ok := current.(*pollingFetcher); ok {
+		return
+	}
+
+	next := af.factory.newPolling(af.baseOptions, fetcherChannels{
+		ready:         af.internalReady,
+		update:        af.internalUpdate,
+		errorChannels: af.baseChannels.errorChannels,
+	})
+
+	af.currentFetcher.Store(&fetchContainer{f: next})
+
+	next.start()
+	current.stop()
+}
+
+func (af *adaptiveFetcher) start() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.started || af.stopped {
+		return
+	}
+	af.started = true
+
+	go af.superviseFetchers()
+	af.currentFetcher.Load().f.start()
+}
+
+func (af *adaptiveFetcher) snapshot() *FeatureMemoryState {
+	return af.currentFetcher.Load().f.snapshot()
+}
+
+func (af *adaptiveFetcher) stop() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.stopped {
+		return
+	}
+	af.stopped = true
+	af.cancel()
+	af.currentFetcher.Load().f.stop()
+}

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -1,0 +1,185 @@
+package unleash
+
+import (
+	"testing"
+
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+)
+
+type fakeFetcher struct {
+	startCalls int
+	stopCalls  int
+	state      *FeatureMemoryState
+}
+
+func (f *fakeFetcher) start() {
+	f.startCalls++
+}
+
+func (f *fakeFetcher) stop() {
+	f.stopCalls++
+}
+
+func (f *fakeFetcher) snapshot() *FeatureMemoryState {
+	return f.state
+}
+
+func makeBaseChannels() fetcherChannels {
+	return fetcherChannels{
+		errorChannels: errorChannels{
+			errors:   make(chan error, 1),
+			warnings: make(chan error, 1),
+		},
+		ready:  make(chan bool, 1),
+		update: make(chan bool, 1),
+	}
+}
+
+func makeTestFactory(streamingFetcher *fakeFetcher, pollingFetcher *fakeFetcher) fetcherFactory {
+	return fetcherFactory{
+		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return streamingFetcher
+		},
+		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return pollingFetcher
+		},
+	}
+}
+
+func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	}
+
+	af.cutover()
+
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	}
+
+	if polling.startCalls != 1 {
+		t.Fatalf("expected polling fetcher to start once, got %d", polling.startCalls)
+	}
+
+	got := af.snapshot()
+	if _, ok := got.Features["polling"]; !ok {
+		t.Fatalf("expected snapshot from polling fetcher after cutover")
+	}
+}
+
+func TestAdaptiveFetcher_StartIsIdempotent(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	}
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to not start again, got %d", streaming.startCalls)
+	}
+}
+
+func TestAdaptiveFetcher_StopIsIdempotent(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	af.stop()
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	}
+
+	af.stop()
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to not stop again, got %d", streaming.stopCalls)
+	}
+}
+
+func TestAdaptiveFetcher_SnapshotDelegatesToCurrentFetcher(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	got := af.snapshot()
+	if _, ok := got.Features["streaming"]; !ok {
+		t.Fatalf("expected snapshot from streaming fetcher")
+	}
+}
+
+func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	af.cutover()
+
+	got := af.snapshot()
+	if _, ok := got.Features["polling"]; !ok {
+		t.Fatalf("expected snapshot from polling fetcher after cutover")
+	}
+}


### PR DESCRIPTION
Basic adaptive fetcher implementation that should allow us to do streaming failover. Not wired up, that's done in #255.

Go's per-emptive concurrency model makes synchronizing this correctly with stop/start a huge pain in the butt so I've chosen to keep this internal only - you make an adaptiveFetcher and it does it's thing, you're not intended to pass in polling+streaming fetchers.This means fetchers continue to be start once, stop once, never restart

Currently the adaptiveFetcher doesn't wait for readiness signals from streaming before cutting over to the pollingFetcher. I'm aware, it's coming in the next set of PRs. With most setups this doesn't matter since it'll read from backup. Will be fixed before release