### PR TITLE
feat: add in failover strategy

### DIFF
--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -14,14 +14,14 @@ type fetchContainer struct {
 }
 
 type fetcherFactory struct {
-	newStreaming func(fetcherOptions, fetcherChannels) togglerFetcher
+	newStreaming func(fetcherOptions, fetcherChannels, chan streamError) togglerFetcher
 	newPolling   func(fetcherOptions, fetcherChannels) togglerFetcher
 }
 
 func defaultFetcherFactory() fetcherFactory {
 	return fetcherFactory{
-		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
-			return newStreamingFetcher(options, channels)
+		newStreaming: func(options fetcherOptions, channels fetcherChannels, streamErrorChannel chan streamError) togglerFetcher {
+			return newStreamingFetcher(options, channels, streamErrorChannel)
 		},
 		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
 			return newPollingFetcher(options, channels)
@@ -30,18 +30,19 @@ func defaultFetcherFactory() fetcherFactory {
 }
 
 type adaptiveFetcher struct {
-	currentFetcher atomic.Pointer[fetchContainer]
-	baseOptions    fetcherOptions
-	baseChannels   fetcherChannels
-	internalReady  chan bool
-	internalUpdate chan bool
-	ready          atomic.Bool
-	started        bool
-	stopped        bool
-	ctx            context.Context
-	cancel         context.CancelFunc
-	mu             sync.Mutex
-	factory        fetcherFactory
+	currentFetcher        atomic.Pointer[fetchContainer]
+	baseOptions           fetcherOptions
+	baseChannels          fetcherChannels
+	internalReady         chan bool
+	internalUpdate        chan bool
+	failoverSignalChannel chan streamError
+	ready                 atomic.Bool
+	started               bool
+	stopped               bool
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	mu                    sync.Mutex
+	factory               fetcherFactory
 }
 
 func newAdaptiveFetcher(options fetcherOptions, channels fetcherChannels) *adaptiveFetcher {
@@ -59,24 +60,26 @@ func newAdaptiveFetcherWithFactory(
 ) *adaptiveFetcher {
 	ir := make(chan bool, 1)
 	iu := make(chan bool, 1)
+	se := make(chan streamError, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	af := &adaptiveFetcher{
-		baseOptions:    options,
-		baseChannels:   channels,
-		internalReady:  ir,
-		internalUpdate: iu,
-		ctx:            ctx,
-		cancel:         cancel,
-		factory:        factory,
+		baseOptions:           options,
+		baseChannels:          channels,
+		internalReady:         ir,
+		internalUpdate:        iu,
+		ctx:                   ctx,
+		cancel:                cancel,
+		factory:               factory,
+		failoverSignalChannel: se,
 	}
 
 	initial := af.factory.newStreaming(options, fetcherChannels{
 		ready:         ir,
 		update:        iu,
 		errorChannels: channels.errorChannels,
-	})
+	}, af.failoverSignalChannel)
 
 	af.currentFetcher.Store(&fetchContainer{f: initial})
 
@@ -92,6 +95,8 @@ func (af *adaptiveFetcher) superviseFetchers() {
 			}
 		case <-af.internalUpdate:
 			af.baseChannels.update <- true
+		case <-af.failoverSignalChannel:
+			// do nothing for now but this is where cutover will get triggered from
 		case <-af.ctx.Done():
 			return
 		}

--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -1,0 +1,151 @@
+package unleash
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// This exists purely because atomics must contain a single concrete type
+// we want to be able to both switch fetcher types and avoid mutexes so this
+// leaves us with this sad little container struct. Don't "fix" this
+type fetchContainer struct {
+	f togglerFetcher
+}
+
+type fetcherFactory struct {
+	newStreaming func(fetcherOptions, fetcherChannels) togglerFetcher
+	newPolling   func(fetcherOptions, fetcherChannels) togglerFetcher
+}
+
+func defaultFetcherFactory() fetcherFactory {
+	return fetcherFactory{
+		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return newStreamingFetcher(options, channels)
+		},
+		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return newPollingFetcher(options, channels)
+		},
+	}
+}
+
+type adaptiveFetcher struct {
+	currentFetcher atomic.Pointer[fetchContainer]
+	baseOptions    fetcherOptions
+	baseChannels   fetcherChannels
+	internalReady  chan bool
+	internalUpdate chan bool
+	ready          atomic.Bool
+	started        bool
+	stopped        bool
+	ctx            context.Context
+	cancel         context.CancelFunc
+	mu             sync.Mutex
+	factory        fetcherFactory
+}
+
+func newAdaptiveFetcher(options fetcherOptions, channels fetcherChannels) *adaptiveFetcher {
+	return newAdaptiveFetcherWithFactory(options, channels, defaultFetcherFactory())
+}
+
+// If you're considering using this in production code, probably don't. This is exposed
+// internally so that test code has a seam to inject fake fetchers and control the lifecycle.
+// Prefer using newAdaptiveFetcher, which will construct appropriate fetchers for
+// real world usage
+func newAdaptiveFetcherWithFactory(
+	options fetcherOptions,
+	channels fetcherChannels,
+	factory fetcherFactory,
+) *adaptiveFetcher {
+	ir := make(chan bool, 1)
+	iu := make(chan bool, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	af := &adaptiveFetcher{
+		baseOptions:    options,
+		baseChannels:   channels,
+		internalReady:  ir,
+		internalUpdate: iu,
+		ctx:            ctx,
+		cancel:         cancel,
+		factory:        factory,
+	}
+
+	initial := af.factory.newStreaming(options, fetcherChannels{
+		ready:         ir,
+		update:        iu,
+		errorChannels: channels.errorChannels,
+	})
+
+	af.currentFetcher.Store(&fetchContainer{f: initial})
+
+	return af
+}
+
+func (af *adaptiveFetcher) superviseFetchers() {
+	for {
+		select {
+		case <-af.internalReady:
+			if af.ready.CompareAndSwap(false, true) {
+				af.baseChannels.ready <- true
+			}
+		case <-af.internalUpdate:
+			af.baseChannels.update <- true
+		case <-af.ctx.Done():
+			return
+		}
+	}
+}
+
+func (af *adaptiveFetcher) cutover() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.stopped {
+		return
+	}
+
+	current := af.currentFetcher.Load().f
+
+	if _, ok := current.(*pollingFetcher); ok {
+		return
+	}
+
+	next := af.factory.newPolling(af.baseOptions, fetcherChannels{
+		ready:         af.internalReady,
+		update:        af.internalUpdate,
+		errorChannels: af.baseChannels.errorChannels,
+	})
+
+	af.currentFetcher.Store(&fetchContainer{f: next})
+
+	next.start()
+	current.stop()
+}
+
+func (af *adaptiveFetcher) start() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.started || af.stopped {
+		return
+	}
+	af.started = true
+
+	go af.superviseFetchers()
+	af.currentFetcher.Load().f.start()
+}
+
+func (af *adaptiveFetcher) snapshot() *FeatureMemoryState {
+	return af.currentFetcher.Load().f.snapshot()
+}
+
+func (af *adaptiveFetcher) stop() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+	if af.stopped {
+		return
+	}
+	af.stopped = true
+	af.cancel()
+	af.currentFetcher.Load().f.stop()
+}

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -1,0 +1,185 @@
+package unleash
+
+import (
+	"testing"
+
+	"github.com/Unleash/unleash-go-sdk/v6/api"
+)
+
+type fakeFetcher struct {
+	startCalls int
+	stopCalls  int
+	state      *FeatureMemoryState
+}
+
+func (f *fakeFetcher) start() {
+	f.startCalls++
+}
+
+func (f *fakeFetcher) stop() {
+	f.stopCalls++
+}
+
+func (f *fakeFetcher) snapshot() *FeatureMemoryState {
+	return f.state
+}
+
+func makeBaseChannels() fetcherChannels {
+	return fetcherChannels{
+		errorChannels: errorChannels{
+			errors:   make(chan error, 1),
+			warnings: make(chan error, 1),
+		},
+		ready:  make(chan bool, 1),
+		update: make(chan bool, 1),
+	}
+}
+
+func makeTestFactory(streamingFetcher *fakeFetcher, pollingFetcher *fakeFetcher) fetcherFactory {
+	return fetcherFactory{
+		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return streamingFetcher
+		},
+		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+			return pollingFetcher
+		},
+	}
+}
+
+func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	}
+
+	af.cutover()
+
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	}
+
+	if polling.startCalls != 1 {
+		t.Fatalf("expected polling fetcher to start once, got %d", polling.startCalls)
+	}
+
+	got := af.snapshot()
+	if _, ok := got.Features["polling"]; !ok {
+		t.Fatalf("expected snapshot from polling fetcher after cutover")
+	}
+}
+
+func TestAdaptiveFetcher_StartIsIdempotent(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	}
+
+	af.start()
+	if streaming.startCalls != 1 {
+		t.Fatalf("expected streaming fetcher to not start again, got %d", streaming.startCalls)
+	}
+}
+
+func TestAdaptiveFetcher_StopIsIdempotent(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	af.stop()
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	}
+
+	af.stop()
+	if streaming.stopCalls != 1 {
+		t.Fatalf("expected streaming fetcher to not stop again, got %d", streaming.stopCalls)
+	}
+}
+
+func TestAdaptiveFetcher_SnapshotDelegatesToCurrentFetcher(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, nil)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	got := af.snapshot()
+	if _, ok := got.Features["streaming"]; !ok {
+		t.Fatalf("expected snapshot from streaming fetcher")
+	}
+}
+
+func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+
+	af.start()
+	af.cutover()
+
+	got := af.snapshot()
+	if _, ok := got.Features["polling"]; !ok {
+		t.Fatalf("expected snapshot from polling fetcher after cutover")
+	}
+}

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -37,7 +37,7 @@ func makeBaseChannels() fetcherChannels {
 
 func makeTestFactory(streamingFetcher *fakeFetcher, pollingFetcher *fakeFetcher) fetcherFactory {
 	return fetcherFactory{
-		newStreaming: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
+		newStreaming: func(options fetcherOptions, channels fetcherChannels, streamErrorChannel chan streamError) togglerFetcher {
 			return streamingFetcher
 		},
 		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {

--- a/client.go
+++ b/client.go
@@ -224,6 +224,7 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 		uc.fetcher = newStreamingFetcher(
 			fetcherOptions,
 			fetcherChannels,
+			nil,
 		)
 	} else {
 		uc.fetcher = newPollingFetcher(

--- a/failover.go
+++ b/failover.go
@@ -1,0 +1,87 @@
+package unleash
+
+import (
+	"time"
+)
+
+type failEvent interface {
+	OccurredAt() time.Time
+	Message() string
+}
+
+type baseFailEvent struct {
+	occurredAt time.Time
+	message    string
+}
+
+func (b *baseFailEvent) OccurredAt() time.Time { return b.occurredAt }
+func (b *baseFailEvent) Message() string       { return b.message }
+
+type networkErrorEvent struct {
+	baseFailEvent
+	err error
+}
+
+type httpStatusErrorEvent struct {
+	baseFailEvent
+	statusCode int
+}
+
+type serverEvent struct {
+	baseFailEvent
+	event string
+}
+
+type failoverStrategy struct {
+	failures  []failEvent
+	maxFails  int
+	relaxTime time.Duration
+}
+
+func newFailoverStrategy(maxFails int, relaxTime time.Duration) *failoverStrategy {
+	return &failoverStrategy{
+		failures:  make([]failEvent, 0, maxFails),
+		maxFails:  maxFails,
+		relaxTime: relaxTime,
+	}
+}
+
+func (f *failoverStrategy) shouldFailover(event failEvent, now time.Time) bool {
+	f.pruneOldFailures(now)
+
+	switch e := event.(type) {
+	case *networkErrorEvent:
+		return f.hasTooManyFails(event)
+	case *httpStatusErrorEvent:
+		switch e.statusCode {
+		case 401, 403, 404, 429, 501:
+			return true
+		case 408, 500, 502, 503, 504:
+			return f.hasTooManyFails(event)
+		default:
+			return false
+		}
+	case *serverEvent:
+		return e.event == "polling"
+	default:
+		return false
+	}
+}
+
+func (f *failoverStrategy) pruneOldFailures(now time.Time) {
+	cutoff := now.Add(-f.relaxTime)
+
+	write := 0
+	for _, fail := range f.failures {
+		if !fail.OccurredAt().Before(cutoff) {
+			f.failures[write] = fail
+			write++
+		}
+	}
+	f.failures = f.failures[:write]
+}
+
+func (f *failoverStrategy) hasTooManyFails(event failEvent) bool {
+	f.failures = append(f.failures, event)
+	return len(f.failures) >= f.maxFails
+}

--- a/failover_test.go
+++ b/failover_test.go
@@ -1,0 +1,138 @@
+package unleash
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestFailoverStrategy_ServerHintPollingFailsOver(t *testing.T) {
+	strategy := newFailoverStrategy(3, 10*time.Second)
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	event := &serverEvent{
+		baseFailEvent: baseFailEvent{
+			occurredAt: now,
+			message:    "Unleash has requested failover to polling",
+		},
+		event: "polling",
+	}
+
+	if got := strategy.shouldFailover(event, now); !got {
+		t.Fatalf("expected failover on server polling hint")
+	}
+}
+
+func TestFailoverStrategy_ArbitraryServerEventDoesNotFailover(t *testing.T) {
+	strategy := newFailoverStrategy(3, 10*time.Second)
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	event := &serverEvent{
+		baseFailEvent: baseFailEvent{
+			occurredAt: now,
+			message:    "Service should frob the wranglebinder now",
+		},
+		event: "a-new-and-exciting-unsupported-event",
+	}
+
+	if got := strategy.shouldFailover(event, now); got {
+		t.Fatalf("expected no failover on arbitrary server event")
+	}
+}
+
+func TestFailoverStrategy_HardHttpStatusCodesFailoverImmediately(t *testing.T) {
+	strategy := newFailoverStrategy(3, 10*time.Second)
+	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, statusCode := range []int{401, 403, 404, 429} {
+		event := &httpStatusErrorEvent{
+			baseFailEvent: baseFailEvent{
+				occurredAt: now,
+				message:    fmt.Sprintf("HTTP status error with status code %d", statusCode),
+			},
+			statusCode: statusCode,
+		}
+
+		if got := strategy.shouldFailover(event, now); !got {
+			t.Fatalf("expected failover on hard status code %d", statusCode)
+		}
+	}
+}
+
+func TestFailoverStrategy_SoftErrorsAccumulateWithinRelaxWindow(t *testing.T) {
+	strategy := newFailoverStrategy(3, 60*time.Second)
+	base := time.Date(1867, 11, 7, 0, 0, 0, 0, time.UTC)
+
+	mkEvent := func(offsetMs int) *httpStatusErrorEvent {
+		occurredAt := base.Add(time.Duration(offsetMs) * time.Millisecond)
+		return &httpStatusErrorEvent{
+			baseFailEvent: baseFailEvent{
+				occurredAt: occurredAt,
+				message:    "HTTP status error with status code 503",
+			},
+			statusCode: 503,
+		}
+	}
+
+	if got := strategy.shouldFailover(mkEvent(0), base); got {
+		t.Fatalf("expected no failover on first soft error")
+	}
+
+	if got := strategy.shouldFailover(mkEvent(1000), base.Add(1000*time.Millisecond)); got {
+		t.Fatalf("expected no failover on second soft error")
+	}
+
+	if got := strategy.shouldFailover(mkEvent(2000), base.Add(2000*time.Millisecond)); !got {
+		t.Fatalf("expected failover on third soft error within relax window")
+	}
+}
+
+func TestFailoverStrategy_SoftErrorsPrunedByWindow(t *testing.T) {
+	strategy := newFailoverStrategy(3, 1*time.Second)
+	base := time.Date(1867, 11, 7, 0, 0, 0, 0, time.UTC)
+
+	mkEvent := func(offsetMs int) *httpStatusErrorEvent {
+		occurredAt := base.Add(time.Duration(offsetMs) * time.Millisecond)
+		return &httpStatusErrorEvent{
+			baseFailEvent: baseFailEvent{
+				occurredAt: occurredAt,
+				message:    "HTTP status error with status code 502",
+			},
+			statusCode: 502,
+		}
+	}
+
+	if got := strategy.shouldFailover(mkEvent(0), base); got {
+		t.Fatalf("expected no failover on first soft error")
+	}
+
+	if got := strategy.shouldFailover(mkEvent(2000), base.Add(2000*time.Millisecond)); got {
+		t.Fatalf("expected no failover on second soft error after window")
+	}
+
+	if got := strategy.shouldFailover(mkEvent(3000), base.Add(3000*time.Millisecond)); got {
+		t.Fatalf("expected no failover on third soft error after pruning")
+	}
+}
+
+func TestFailoverStrategy_UnhandledStatusCodesNeverFailover(t *testing.T) {
+	strategy := newFailoverStrategy(1, 10*time.Second)
+	base := time.Date(1867, 11, 7, 0, 0, 0, 0, time.UTC)
+
+	mkEvent := func(code int, offsetMs int) *httpStatusErrorEvent {
+		occurredAt := base.Add(time.Duration(offsetMs) * time.Millisecond)
+		return &httpStatusErrorEvent{
+			baseFailEvent: baseFailEvent{
+				occurredAt: occurredAt,
+				message:    fmt.Sprintf("HTTP status error with status code %d", code),
+			},
+			statusCode: code,
+		}
+	}
+
+	for _, statusCode := range []int{418, 418, 418, 418} {
+		if got := strategy.shouldFailover(mkEvent(statusCode, 0), base); got {
+			t.Fatalf("expected no failover on unhandled status code %d", statusCode)
+		}
+	}
+}

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -27,21 +27,20 @@ type streamError struct {
 
 type streamingFetcher struct {
 	fetcherChannels
-	url            string
-	appName        string
-	instanceId     string
-	httpClient     *http.Client
-	headers        http.Header
-	stream         *eventsource.Stream
-	storage        Storage
-	deltaProcessor *deltaProcessor
-	ctx            context.Context
-	cancel         context.CancelFunc
-	hydrated       atomic.Bool
-	internalErrors chan streamError
+	url                string
+	appName            string
+	instanceId         string
+	httpClient         *http.Client
+	headers            http.Header
+	storage            Storage
+	deltaProcessor     *deltaProcessor
+	ctx                context.Context
+	cancel             context.CancelFunc
+	hydrated           atomic.Bool
+	streamErrorChannel chan streamError
 }
 
-func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels) *streamingFetcher {
+func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels, streamErrorChannel chan streamError) *streamingFetcher {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var apiResponse *api.FeatureResponse
@@ -58,17 +57,17 @@ func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels
 	deltaProc := newDeltaProcessor(apiResponse)
 
 	streamingFetcher := &streamingFetcher{
-		url:             fmt.Sprintf("%sclient/streaming", options.url.String()),
-		appName:         options.appName,
-		instanceId:      options.instanceId,
-		httpClient:      options.httpClient,
-		headers:         options.headers,
-		deltaProcessor:  deltaProc,
-		ctx:             ctx,
-		cancel:          cancel,
-		fetcherChannels: fetcherChannels,
-		internalErrors:  make(chan streamError, 8),
-		storage:         options.storage,
+		url:                fmt.Sprintf("%sclient/streaming", options.url.String()),
+		appName:            options.appName,
+		instanceId:         options.instanceId,
+		httpClient:         options.httpClient,
+		headers:            options.headers,
+		deltaProcessor:     deltaProc,
+		ctx:                ctx,
+		cancel:             cancel,
+		fetcherChannels:    fetcherChannels,
+		streamErrorChannel: streamErrorChannel,
+		storage:            options.storage,
 	}
 
 	return streamingFetcher
@@ -77,7 +76,7 @@ func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels
 func (sc *streamingFetcher) start() {
 	req, err := http.NewRequestWithContext(sc.ctx, "GET", sc.url, nil)
 	if err != nil {
-		sc.internalErrors <- streamError{kind: fatal, err: fmt.Errorf("failed to create request: %w", err)}
+		sc.signalStreamingError(streamError{kind: fatal, err: fmt.Errorf("failed to create request: %w", err)})
 		return
 	}
 
@@ -93,7 +92,6 @@ func (sc *streamingFetcher) start() {
 	req.Header.Add("User-Agent", sc.appName)
 
 	go sc.runStream(req)
-	go sc.superviseStream()
 }
 
 func (sc *streamingFetcher) runStream(req *http.Request) {
@@ -102,17 +100,15 @@ func (sc *streamingFetcher) runStream(req *http.Request) {
 		eventsource.StreamOptionUseBackoff(5*time.Minute),
 		eventsource.StreamOptionUseJitter(0.5),
 		eventsource.StreamOptionErrorHandler(func(err error) eventsource.StreamErrorHandlerResult {
-			sc.internalErrors <- streamError{kind: transient, err: fmt.Errorf("SSE error: %w", err)}
+			sc.signalStreamingError(streamError{kind: transient, err: fmt.Errorf("SSE error: %w", err)})
 			return eventsource.StreamErrorHandlerResult{CloseNow: false}
 		}),
 	)
 
 	if err != nil {
-		sc.internalErrors <- streamError{kind: fatal, err: fmt.Errorf("failed to subscribe to SSE stream: %w", err)}
+		sc.signalStreamingError(streamError{kind: fatal, err: fmt.Errorf("failed to subscribe to SSE stream: %w", err)})
 		return
 	}
-
-	sc.stream = stream
 
 	for {
 		select {
@@ -123,27 +119,11 @@ func (sc *streamingFetcher) runStream(req *http.Request) {
 			switch event.Event() {
 			case "unleash-connected", "unleash-updated":
 				if err := sc.handleDomainEvent(event); err != nil {
-					sc.internalErrors <- streamError{kind: corrupted, err: fmt.Errorf("failed to handle event: %w", err)}
+					sc.signalStreamingError(streamError{kind: corrupted, err: fmt.Errorf("failed to handle event: %w", err)})
 				}
 			}
 		case <-sc.ctx.Done():
 			stream.Close()
-			return
-		}
-	}
-}
-
-func (sc *streamingFetcher) superviseStream() {
-	// this intentionally just black holes errors. This is incomplete
-	// in this PR and will be fleshed out in the next steps
-	for {
-		select {
-		case _, ok := <-sc.internalErrors:
-			if !ok {
-				return
-			}
-
-		case <-sc.ctx.Done():
 			return
 		}
 	}
@@ -192,4 +172,10 @@ func (sc *streamingFetcher) snapshot() *FeatureMemoryState {
 
 func (sc *streamingFetcher) stop() {
 	sc.cancel()
+}
+
+func (sc *streamingFetcher) signalStreamingError(sig streamError) {
+	if sc.streamErrorChannel != nil {
+		sc.streamErrorChannel <- sig
+	}
 }


### PR DESCRIPTION
More or less a direct port of the Node/Java/C# SDKs' failover strategy. Main code is human rolled and a little adapted to be more Go idiomatic. Test code was done by pointing Codex at the Node tests and asking for a port - human verified but AI rolled