### PR TITLE
feat: wire up adaptive and streaming fetchers

### DIFF
--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -2,6 +2,7 @@ package unleash
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 )
@@ -14,14 +15,14 @@ type fetchContainer struct {
 }
 
 type fetcherFactory struct {
-	newStreaming func(fetcherOptions, fetcherChannels, chan streamError) togglerFetcher
+	newStreaming func(fetcherOptions, fetcherChannels, chan failEvent) togglerFetcher
 	newPolling   func(fetcherOptions, fetcherChannels) togglerFetcher
 }
 
 func defaultFetcherFactory() fetcherFactory {
 	return fetcherFactory{
-		newStreaming: func(options fetcherOptions, channels fetcherChannels, streamErrorChannel chan streamError) togglerFetcher {
-			return newStreamingFetcher(options, channels, streamErrorChannel)
+		newStreaming: func(options fetcherOptions, channels fetcherChannels, failoverChannel chan failEvent) togglerFetcher {
+			return newStreamingFetcher(options, channels, failoverChannel)
 		},
 		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
 			return newPollingFetcher(options, channels)
@@ -35,7 +36,7 @@ type adaptiveFetcher struct {
 	baseChannels          fetcherChannels
 	internalReady         chan bool
 	internalUpdate        chan bool
-	failoverSignalChannel chan streamError
+	failoverSignalChannel chan failEvent
 	ready                 atomic.Bool
 	started               bool
 	stopped               bool
@@ -60,7 +61,7 @@ func newAdaptiveFetcherWithFactory(
 ) *adaptiveFetcher {
 	ir := make(chan bool, 1)
 	iu := make(chan bool, 1)
-	se := make(chan streamError, 1)
+	fc := make(chan failEvent, 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -72,7 +73,7 @@ func newAdaptiveFetcherWithFactory(
 		ctx:                   ctx,
 		cancel:                cancel,
 		factory:               factory,
-		failoverSignalChannel: se,
+		failoverSignalChannel: fc,
 	}
 
 	initial := af.factory.newStreaming(options, fetcherChannels{
@@ -95,8 +96,9 @@ func (af *adaptiveFetcher) superviseFetchers() {
 			}
 		case <-af.internalUpdate:
 			af.baseChannels.update <- true
-		case <-af.failoverSignalChannel:
-			// do nothing for now but this is where cutover will get triggered from
+		case errorEvent := <-af.failoverSignalChannel:
+			af.baseChannels.warnings <- fmt.Errorf("Adaptive fetcher failover triggered: %s", errorEvent.Message())
+			af.cutover()
 		case <-af.ctx.Done():
 			return
 		}

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -2,6 +2,7 @@ package unleash
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v6/api"
 )
@@ -37,12 +38,30 @@ func makeBaseChannels() fetcherChannels {
 
 func makeTestFactory(streamingFetcher *fakeFetcher, pollingFetcher *fakeFetcher) fetcherFactory {
 	return fetcherFactory{
-		newStreaming: func(options fetcherOptions, channels fetcherChannels, streamErrorChannel chan streamError) togglerFetcher {
+		newStreaming: func(options fetcherOptions, channels fetcherChannels, failoverSignal chan failEvent) togglerFetcher {
 			return streamingFetcher
 		},
 		newPolling: func(options fetcherOptions, channels fetcherChannels) togglerFetcher {
 			return pollingFetcher
 		},
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, onTimeout string) {
+	t.Helper()
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		if cond() {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf(onTimeout)
+		case <-ticker.C:
+		}
 	}
 }
 
@@ -181,5 +200,53 @@ func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
 	got := af.snapshot()
 	if _, ok := got.Features["polling"]; !ok {
 		t.Fatalf("expected snapshot from polling fetcher after cutover")
+	}
+}
+
+func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+	af.start()
+
+	failEvent := &failoverRequest{
+		baseFailEvent: baseFailEvent{
+			occurredAt: time.Now(),
+			message:    "streaming borked",
+		},
+	}
+
+	select {
+	case af.failoverSignalChannel <- failEvent:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending failover signal")
+	}
+
+	waitFor(t, 500*time.Millisecond, func() bool {
+		return polling.startCalls == 1 && streaming.stopCalls == 1
+	}, "expected cutover to polling after failover signal")
+
+	select {
+	case err := <-channels.warnings:
+		if err == nil || err.Error() == "" {
+			t.Fatalf("expected warning error on failover")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected warning to be emitted on failover")
 	}
 }

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -1,6 +1,7 @@
 package unleash
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -8,17 +9,17 @@ import (
 )
 
 type fakeFetcher struct {
-	startCalls int
-	stopCalls  int
+	startCalls atomic.Int32
+	stopCalls  atomic.Int32
 	state      *FeatureMemoryState
 }
 
 func (f *fakeFetcher) start() {
-	f.startCalls++
+	f.startCalls.Add(1)
 }
 
 func (f *fakeFetcher) stop() {
-	f.stopCalls++
+	f.stopCalls.Add(1)
 }
 
 func (f *fakeFetcher) snapshot() *FeatureMemoryState {
@@ -86,18 +87,18 @@ func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 
 	af.start()
-	if streaming.startCalls != 1 {
-		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	if streaming.startCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls.Load())
 	}
 
 	af.cutover()
 
-	if streaming.stopCalls != 1 {
-		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	if streaming.stopCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls.Load())
 	}
 
-	if polling.startCalls != 1 {
-		t.Fatalf("expected polling fetcher to start once, got %d", polling.startCalls)
+	if polling.startCalls.Load() != 1 {
+		t.Fatalf("expected polling fetcher to start once, got %d", polling.startCalls.Load())
 	}
 
 	got := af.snapshot()
@@ -120,13 +121,13 @@ func TestAdaptiveFetcher_StartIsIdempotent(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 
 	af.start()
-	if streaming.startCalls != 1 {
-		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls)
+	if streaming.startCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls.Load())
 	}
 
 	af.start()
-	if streaming.startCalls != 1 {
-		t.Fatalf("expected streaming fetcher to not start again, got %d", streaming.startCalls)
+	if streaming.startCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to not start again, got %d", streaming.startCalls.Load())
 	}
 }
 
@@ -145,13 +146,13 @@ func TestAdaptiveFetcher_StopIsIdempotent(t *testing.T) {
 
 	af.start()
 	af.stop()
-	if streaming.stopCalls != 1 {
-		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls)
+	if streaming.stopCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls.Load())
 	}
 
 	af.stop()
-	if streaming.stopCalls != 1 {
-		t.Fatalf("expected streaming fetcher to not stop again, got %d", streaming.stopCalls)
+	if streaming.stopCalls.Load() != 1 {
+		t.Fatalf("expected streaming fetcher to not stop again, got %d", streaming.stopCalls.Load())
 	}
 }
 
@@ -238,7 +239,7 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 	}
 
 	waitFor(t, 500*time.Millisecond, func() bool {
-		return polling.startCalls == 1 && streaming.stopCalls == 1
+		return polling.startCalls.Load() == 1 && streaming.stopCalls.Load() == 1
 	}, "expected cutover to polling after failover signal")
 
 	select {

--- a/failover.go
+++ b/failover.go
@@ -27,9 +27,8 @@ type httpStatusErrorEvent struct {
 	statusCode int
 }
 
-type serverEvent struct {
+type failoverRequest struct {
 	baseFailEvent
-	event string
 }
 
 type failoverStrategy struct {
@@ -61,8 +60,8 @@ func (f *failoverStrategy) shouldFailover(event failEvent, now time.Time) bool {
 		default:
 			return false
 		}
-	case *serverEvent:
-		return e.event == "polling"
+	case *failoverRequest:
+		return true
 	default:
 		return false
 	}

--- a/failover_test.go
+++ b/failover_test.go
@@ -10,33 +10,15 @@ func TestFailoverStrategy_ServerHintPollingFailsOver(t *testing.T) {
 	strategy := newFailoverStrategy(3, 10*time.Second)
 	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	event := &serverEvent{
+	event := &failoverRequest{
 		baseFailEvent: baseFailEvent{
 			occurredAt: now,
 			message:    "Unleash has requested failover to polling",
 		},
-		event: "polling",
 	}
 
 	if got := strategy.shouldFailover(event, now); !got {
 		t.Fatalf("expected failover on server polling hint")
-	}
-}
-
-func TestFailoverStrategy_ArbitraryServerEventDoesNotFailover(t *testing.T) {
-	strategy := newFailoverStrategy(3, 10*time.Second)
-	now := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-
-	event := &serverEvent{
-		baseFailEvent: baseFailEvent{
-			occurredAt: now,
-			message:    "Service should frob the wranglebinder now",
-		},
-		event: "a-new-and-exciting-unsupported-event",
-	}
-
-	if got := strategy.shouldFailover(event, now); got {
-		t.Fatalf("expected no failover on arbitrary server event")
 	}
 }
 

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -11,36 +12,37 @@ import (
 	"github.com/launchdarkly/eventsource"
 )
 
-type streamErrorKind int
-
-const (
-	transient streamErrorKind = iota
-	warning
-	fatal
-	corrupted
-)
-
-type streamError struct {
-	kind streamErrorKind
-	err  error
-}
-
 type streamingFetcher struct {
 	fetcherChannels
-	url                string
-	appName            string
-	instanceId         string
-	httpClient         *http.Client
-	headers            http.Header
-	storage            Storage
-	deltaProcessor     *deltaProcessor
-	ctx                context.Context
-	cancel             context.CancelFunc
-	hydrated           atomic.Bool
-	streamErrorChannel chan streamError
+	url             string
+	appName         string
+	instanceId      string
+	httpClient      *http.Client
+	headers         http.Header
+	storage         Storage
+	deltaProcessor  *deltaProcessor
+	ctx             context.Context
+	cancel          context.CancelFunc
+	hydrated        atomic.Bool
+	recordFailEvent func(failEvent)
 }
 
-func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels, streamErrorChannel chan streamError) *streamingFetcher {
+func buildFailoverRecorder(ch chan failEvent, failoverStrategy *failoverStrategy) func(failEvent) {
+	if ch == nil {
+		return func(failEvent) {}
+	}
+
+	var once sync.Once
+	return func(reason failEvent) {
+		if failoverStrategy.shouldFailover(reason, time.Now()) {
+			once.Do(func() {
+				ch <- reason
+			})
+		}
+	}
+}
+
+func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels, failoverChannel chan failEvent) *streamingFetcher {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var apiResponse *api.FeatureResponse
@@ -57,17 +59,17 @@ func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels
 	deltaProc := newDeltaProcessor(apiResponse)
 
 	streamingFetcher := &streamingFetcher{
-		url:                fmt.Sprintf("%sclient/streaming", options.url.String()),
-		appName:            options.appName,
-		instanceId:         options.instanceId,
-		httpClient:         options.httpClient,
-		headers:            options.headers,
-		deltaProcessor:     deltaProc,
-		ctx:                ctx,
-		cancel:             cancel,
-		fetcherChannels:    fetcherChannels,
-		streamErrorChannel: streamErrorChannel,
-		storage:            options.storage,
+		url:             fmt.Sprintf("%sclient/streaming", options.url.String()),
+		appName:         options.appName,
+		instanceId:      options.instanceId,
+		httpClient:      options.httpClient,
+		headers:         options.headers,
+		deltaProcessor:  deltaProc,
+		ctx:             ctx,
+		cancel:          cancel,
+		fetcherChannels: fetcherChannels,
+		recordFailEvent: buildFailoverRecorder(failoverChannel, newFailoverStrategy(5, 60*time.Second)),
+		storage:         options.storage,
 	}
 
 	return streamingFetcher
@@ -76,7 +78,7 @@ func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels
 func (sc *streamingFetcher) start() {
 	req, err := http.NewRequestWithContext(sc.ctx, "GET", sc.url, nil)
 	if err != nil {
-		sc.signalStreamingError(streamError{kind: fatal, err: fmt.Errorf("failed to create request: %w", err)})
+		sc.recordFailEvent(&failoverRequest{baseFailEvent: baseFailEvent{occurredAt: time.Now(), message: fmt.Sprintf("unable to setup base http request for streaming fetcher: %v", err)}})
 		return
 	}
 
@@ -100,13 +102,37 @@ func (sc *streamingFetcher) runStream(req *http.Request) {
 		eventsource.StreamOptionUseBackoff(5*time.Minute),
 		eventsource.StreamOptionUseJitter(0.5),
 		eventsource.StreamOptionErrorHandler(func(err error) eventsource.StreamErrorHandlerResult {
-			sc.signalStreamingError(streamError{kind: transient, err: fmt.Errorf("SSE error: %w", err)})
+
+			var event failEvent = nil
+
+			if se, ok := err.(eventsource.SubscriptionError); ok {
+				status := se.Code
+				event = &httpStatusErrorEvent{
+					baseFailEvent: baseFailEvent{
+						occurredAt: time.Now(),
+						message:    fmt.Sprintf("streaming connection error with HTTP status code %d: %v", status, err),
+					},
+					statusCode: status,
+				}
+			} else {
+				event = &networkErrorEvent{
+					baseFailEvent: baseFailEvent{
+						occurredAt: time.Now(),
+						message:    fmt.Sprintf("streaming connection network error: %v", err),
+					},
+					err: err,
+				}
+			}
+			sc.recordFailEvent(event)
+
+			// Don't need to close, this is the job of of the wrapping adaptiveFetcher to decide when
+			// or if to cutover. We just let it know and if it wants to close it'll invoke stop
 			return eventsource.StreamErrorHandlerResult{CloseNow: false}
 		}),
 	)
 
 	if err != nil {
-		sc.signalStreamingError(streamError{kind: fatal, err: fmt.Errorf("failed to subscribe to SSE stream: %w", err)})
+		sc.recordFailEvent(&failoverRequest{baseFailEvent: baseFailEvent{occurredAt: time.Now(), message: fmt.Sprintf("failed to establish streaming connection: %v", err)}})
 		return
 	}
 
@@ -119,7 +145,8 @@ func (sc *streamingFetcher) runStream(req *http.Request) {
 			switch event.Event() {
 			case "unleash-connected", "unleash-updated":
 				if err := sc.handleDomainEvent(event); err != nil {
-					sc.signalStreamingError(streamError{kind: corrupted, err: fmt.Errorf("failed to handle event: %w", err)})
+					// This isn't a case for failover, it's a case for disconnect and request a
+					// fresh hydration. Coming in next chunk of work
 				}
 			}
 		case <-sc.ctx.Done():
@@ -172,10 +199,4 @@ func (sc *streamingFetcher) snapshot() *FeatureMemoryState {
 
 func (sc *streamingFetcher) stop() {
 	sc.cancel()
-}
-
-func (sc *streamingFetcher) signalStreamingError(sig streamError) {
-	if sc.streamErrorChannel != nil {
-		sc.streamErrorChannel <- sig
-	}
 }


### PR DESCRIPTION
Wires up the streaming and adaptive fetchers. This means streaming can now signal to the adaptive fetcher that it's out and wants to fail over.