### PR TITLE
feat: restart poisoned streams instead of leaving corrupted state

### DIFF
--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -14,17 +14,24 @@ import (
 
 type streamingFetcher struct {
 	fetcherChannels
-	url             string
-	appName         string
-	instanceId      string
-	httpClient      *http.Client
-	headers         http.Header
-	storage         Storage
-	deltaProcessor  *deltaProcessor
-	ctx             context.Context
-	cancel          context.CancelFunc
+	url            string
+	appName        string
+	instanceId     string
+	httpClient     *http.Client
+	headers        http.Header
+	storage        Storage
+	deltaProcessor *deltaProcessor
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	streamMu     sync.Mutex
+	streamCancel context.CancelFunc
+
 	hydrated        atomic.Bool
 	recordFailEvent func(failEvent)
+	subscribe       func(*http.Request, ...eventsource.StreamOption) (*eventsource.Stream, error)
+	restartStreamFn func()
 }
 
 func buildFailoverRecorder(ch chan failEvent, failoverStrategy *failoverStrategy) func(failEvent) {
@@ -71,14 +78,39 @@ func newStreamingFetcher(options fetcherOptions, fetcherChannels fetcherChannels
 		recordFailEvent: buildFailoverRecorder(failoverChannel, newFailoverStrategy(5, 60*time.Second)),
 		storage:         options.storage,
 	}
+	streamingFetcher.subscribe = eventsource.SubscribeWithRequestAndOptions
+	streamingFetcher.restartStreamFn = streamingFetcher.restartStream
 
 	return streamingFetcher
 }
 
 func (sc *streamingFetcher) start() {
-	req, err := http.NewRequestWithContext(sc.ctx, "GET", sc.url, nil)
+	sc.restartStream()
+}
+
+func (sc *streamingFetcher) restartStream() {
+	sc.streamMu.Lock()
+	defer sc.streamMu.Unlock()
+
+	if sc.ctx.Err() != nil {
+		return
+	}
+
+	if sc.streamCancel != nil {
+		sc.streamCancel()
+	}
+
+	streamCtx, streamCancel := context.WithCancel(sc.ctx)
+	sc.streamCancel = streamCancel
+
+	req, err := http.NewRequestWithContext(streamCtx, "GET", sc.url, nil)
 	if err != nil {
-		sc.recordFailEvent(&failoverRequest{baseFailEvent: baseFailEvent{occurredAt: time.Now(), message: fmt.Sprintf("unable to setup base http request for streaming fetcher: %v", err)}})
+		sc.recordFailEvent(&failoverRequest{
+			baseFailEvent: baseFailEvent{
+				occurredAt: time.Now(),
+				message:    fmt.Sprintf("unable to setup base http request for streaming fetcher: %v", err),
+			},
+		})
 		return
 	}
 
@@ -93,17 +125,17 @@ func (sc *streamingFetcher) start() {
 	req.Header.Add("Unleash-Client-Spec", SEGMENT_CLIENT_SPEC_VERSION)
 	req.Header.Add("User-Agent", sc.appName)
 
-	go sc.runStream(req)
+	go sc.runStream(streamCtx, req)
 }
 
-func (sc *streamingFetcher) runStream(req *http.Request) {
-	stream, err := eventsource.SubscribeWithRequestAndOptions(req,
+func (sc *streamingFetcher) runStream(streamCtx context.Context, req *http.Request) {
+	stream, err := sc.subscribe(req,
 		eventsource.StreamOptionCanRetryFirstConnection(-time.Second*3),
 		eventsource.StreamOptionUseBackoff(5*time.Minute),
 		eventsource.StreamOptionUseJitter(0.5),
 		eventsource.StreamOptionErrorHandler(func(err error) eventsource.StreamErrorHandlerResult {
 
-			var event failEvent = nil
+			var event failEvent
 
 			if se, ok := err.(eventsource.SubscriptionError); ok {
 				status := se.Code
@@ -145,11 +177,10 @@ func (sc *streamingFetcher) runStream(req *http.Request) {
 			switch event.Event() {
 			case "unleash-connected", "unleash-updated":
 				if err := sc.handleDomainEvent(event); err != nil {
-					// This isn't a case for failover, it's a case for disconnect and request a
-					// fresh hydration. Coming in next chunk of work
+					go sc.restartStreamFn()
 				}
 			}
-		case <-sc.ctx.Done():
+		case <-streamCtx.Done():
 			stream.Close()
 			return
 		}
@@ -199,4 +230,10 @@ func (sc *streamingFetcher) snapshot() *FeatureMemoryState {
 
 func (sc *streamingFetcher) stop() {
 	sc.cancel()
+
+	sc.streamMu.Lock()
+	if sc.streamCancel != nil {
+		sc.streamCancel()
+	}
+	sc.streamMu.Unlock()
 }

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -232,8 +232,9 @@ func (sc *streamingFetcher) stop() {
 	sc.cancel()
 
 	sc.streamMu.Lock()
+	defer sc.streamMu.Unlock()
+	
 	if sc.streamCancel != nil {
 		sc.streamCancel()
 	}
-	sc.streamMu.Unlock()
 }

--- a/streaming_fetcher_test.go
+++ b/streaming_fetcher_test.go
@@ -1,0 +1,69 @@
+package unleash
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/launchdarkly/eventsource"
+)
+
+type testEvent struct {
+	event string
+	data  string
+}
+
+func (e testEvent) Id() string    { return "" }
+func (e testEvent) Event() string { return e.event }
+func (e testEvent) Data() string  { return e.data }
+
+func TestStreamingFetcher_BrokenEventRestartsStream(t *testing.T) {
+	baseURL, err := url.Parse("http://example.com/")
+	if err != nil {
+		t.Fatalf("failed to parse base URL: %v", err)
+	}
+
+	channels := makeBaseChannels()
+	fetcher := newStreamingFetcher(fetcherOptions{
+		appName:    "test-app",
+		instanceId: "test-instance",
+		url:        *baseURL,
+		storage:    &NoOpStorage{},
+		httpClient: http.DefaultClient,
+		headers:    http.Header{},
+	}, channels, nil)
+
+	stream := &eventsource.Stream{
+		Events: make(chan eventsource.Event, 1),
+	}
+
+	fetcher.subscribe = func(*http.Request, ...eventsource.StreamOption) (*eventsource.Stream, error) {
+		return stream, nil
+	}
+
+	restarts := make(chan struct{}, 1)
+	fetcher.restartStreamFn = func() {
+		restarts <- struct{}{}
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/stream", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+
+	go fetcher.runStream(context.Background(), req)
+
+	stream.Events <- testEvent{
+		event: "unleash-updated",
+		data:  "should-be-json-whee",
+	}
+	close(stream.Events)
+
+	select {
+	case <-restarts:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected stream restart after broken event")
+	}
+}


### PR DESCRIPTION
This terminates a stream and restarts it in the case of poisoned events. In theory this should never happen, however, if for some reason the SDK receives a domain event it cannot process then continuing on is not safe - a rehydration from scratch is necessary to maintain data integrity