### PR TITLE
Feat/ready event on cutover

### DIFF
--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -32,7 +32,7 @@ func defaultFetcherFactory() fetcherFactory {
 
 type adaptiveFetcher struct {
 	currentFetcher        atomic.Pointer[fetchContainer]
-	pendingFetcher        togglerFetcher
+	cutoverFetcher        togglerFetcher
 	baseOptions           fetcherOptions
 	baseChannels          fetcherChannels
 	internalReady         chan bool
@@ -118,10 +118,10 @@ func (af *adaptiveFetcher) handleReadyEvent() {
 		return
 	}
 
-	if af.pendingFetcher != nil {
+	if af.cutoverFetcher != nil {
 		af.currentFetcher.Load().f.stop()
-		af.currentFetcher.Store(&fetchContainer{f: af.pendingFetcher})
-		af.pendingFetcher = nil
+		af.currentFetcher.Store(&fetchContainer{f: af.cutoverFetcher})
+		af.cutoverFetcher = nil
 	}
 }
 
@@ -138,7 +138,7 @@ func (af *adaptiveFetcher) cutover() {
 		return
 	}
 
-	if af.pendingFetcher != nil {
+	if af.cutoverFetcher != nil {
 		return
 	}
 
@@ -148,7 +148,7 @@ func (af *adaptiveFetcher) cutover() {
 		errorChannels: af.baseChannels.errorChannels,
 	})
 
-	af.pendingFetcher = next
+	af.cutoverFetcher = next
 
 	next.start()
 }
@@ -179,9 +179,9 @@ func (af *adaptiveFetcher) stop() {
 	af.stopped = true
 	af.cancel()
 
-	if af.pendingFetcher != nil {
-		af.pendingFetcher.stop()
-		af.pendingFetcher = nil
+	if af.cutoverFetcher != nil {
+		af.cutoverFetcher.stop()
+		af.cutoverFetcher = nil
 	}
 
 	af.currentFetcher.Load().f.stop()

--- a/adaptive_fetcher.go
+++ b/adaptive_fetcher.go
@@ -32,6 +32,7 @@ func defaultFetcherFactory() fetcherFactory {
 
 type adaptiveFetcher struct {
 	currentFetcher        atomic.Pointer[fetchContainer]
+	pendingFetcher        togglerFetcher
 	baseOptions           fetcherOptions
 	baseChannels          fetcherChannels
 	internalReady         chan bool
@@ -91,9 +92,7 @@ func (af *adaptiveFetcher) superviseFetchers() {
 	for {
 		select {
 		case <-af.internalReady:
-			if af.ready.CompareAndSwap(false, true) {
-				af.baseChannels.ready <- true
-			}
+			af.handleReadyEvent()
 		case <-af.internalUpdate:
 			af.baseChannels.update <- true
 		case errorEvent := <-af.failoverSignalChannel:
@@ -102,6 +101,27 @@ func (af *adaptiveFetcher) superviseFetchers() {
 		case <-af.ctx.Done():
 			return
 		}
+	}
+}
+
+func (af *adaptiveFetcher) handleReadyEvent() {
+	af.mu.Lock()
+	defer af.mu.Unlock()
+
+	// catch the first ready event - this necessarily must be the startup fetcher
+	// telling us that it's hydrated. From a user perspective this *is* the ready event
+	// after this point we're only ever waiting for a cutover fetcher to signal that
+	// it's ready to take over, which the user doesn't need to know about
+	if !af.ready.Load() {
+		af.ready.Store(true)
+		af.baseChannels.ready <- true
+		return
+	}
+
+	if af.pendingFetcher != nil {
+		af.currentFetcher.Load().f.stop()
+		af.currentFetcher.Store(&fetchContainer{f: af.pendingFetcher})
+		af.pendingFetcher = nil
 	}
 }
 
@@ -118,16 +138,19 @@ func (af *adaptiveFetcher) cutover() {
 		return
 	}
 
+	if af.pendingFetcher != nil {
+		return
+	}
+
 	next := af.factory.newPolling(af.baseOptions, fetcherChannels{
 		ready:         af.internalReady,
 		update:        af.internalUpdate,
 		errorChannels: af.baseChannels.errorChannels,
 	})
 
-	af.currentFetcher.Store(&fetchContainer{f: next})
+	af.pendingFetcher = next
 
 	next.start()
-	current.stop()
 }
 
 func (af *adaptiveFetcher) start() {
@@ -149,10 +172,17 @@ func (af *adaptiveFetcher) snapshot() *FeatureMemoryState {
 func (af *adaptiveFetcher) stop() {
 	af.mu.Lock()
 	defer af.mu.Unlock()
+
 	if af.stopped {
 		return
 	}
 	af.stopped = true
 	af.cancel()
+
+	if af.pendingFetcher != nil {
+		af.pendingFetcher.stop()
+		af.pendingFetcher = nil
+	}
+
 	af.currentFetcher.Load().f.stop()
 }

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -66,6 +66,15 @@ func waitFor(t *testing.T, timeout time.Duration, cond func() bool, onTimeout st
 	}
 }
 
+func waitForReady(t *testing.T, ch chan bool, label string) {
+	t.Helper()
+	select {
+	case ch <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending %s signal", label)
+	}
+}
+
 func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
 	streaming := &fakeFetcher{
 		state: &FeatureMemoryState{
@@ -91,11 +100,7 @@ func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
 		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls.Load())
 	}
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending initial ready signal")
-	}
+	waitForReady(t, af.internalReady, "initial ready")
 
 	af.cutover()
 
@@ -107,11 +112,7 @@ func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
 		t.Fatalf("expected streaming fetcher to keep running until polling is ready, got %d", streaming.stopCalls.Load())
 	}
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending polling ready signal")
-	}
+	waitForReady(t, af.internalReady, "polling ready")
 
 	waitFor(t, 500*time.Millisecond, func() bool {
 		return streaming.stopCalls.Load() == 1
@@ -212,11 +213,7 @@ func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 
 	af.start()
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending initial ready signal")
-	}
+	waitForReady(t, af.internalReady, "initial ready")
 	af.cutover()
 
 	got := af.snapshot()
@@ -224,11 +221,7 @@ func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
 		t.Fatalf("expected snapshot from streaming fetcher before polling ready")
 	}
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending polling ready signal")
-	}
+	waitForReady(t, af.internalReady, "polling ready")
 
 	waitFor(t, 500*time.Millisecond, func() bool {
 		return polling.startCalls.Load() == 1 && streaming.stopCalls.Load() == 1
@@ -261,11 +254,7 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 	af.start()
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending initial ready signal")
-	}
+	waitForReady(t, af.internalReady, "initial ready")
 
 	failEvent := &failoverRequest{
 		baseFailEvent: baseFailEvent{
@@ -288,11 +277,7 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 		t.Fatalf("expected streaming fetcher to keep running until polling is ready, got %d", streaming.stopCalls.Load())
 	}
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending polling ready signal")
-	}
+	waitForReady(t, af.internalReady, "polling ready")
 
 	waitFor(t, 500*time.Millisecond, func() bool {
 		return streaming.stopCalls.Load() == 1
@@ -329,11 +314,7 @@ func TestAdaptiveFetcher_CutoverWaitsForPollingReady(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 	af.start()
 
-	select {
-	case af.internalReady <- true:
-	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("timeout sending initial ready signal")
-	}
+	waitForReady(t, af.internalReady, "initial ready")
 
 	af.cutover()
 

--- a/adaptive_fetcher_test.go
+++ b/adaptive_fetcher_test.go
@@ -91,15 +91,31 @@ func TestAdaptiveFetcher_CutoverSwapsToPolling(t *testing.T) {
 		t.Fatalf("expected streaming fetcher to start once, got %d", streaming.startCalls.Load())
 	}
 
-	af.cutover()
-
-	if streaming.stopCalls.Load() != 1 {
-		t.Fatalf("expected streaming fetcher to stop once, got %d", streaming.stopCalls.Load())
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending initial ready signal")
 	}
+
+	af.cutover()
 
 	if polling.startCalls.Load() != 1 {
 		t.Fatalf("expected polling fetcher to start once, got %d", polling.startCalls.Load())
 	}
+
+	if streaming.stopCalls.Load() != 0 {
+		t.Fatalf("expected streaming fetcher to keep running until polling is ready, got %d", streaming.stopCalls.Load())
+	}
+
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending polling ready signal")
+	}
+
+	waitFor(t, 500*time.Millisecond, func() bool {
+		return streaming.stopCalls.Load() == 1
+	}, "expected streaming fetcher to stop after polling ready")
 
 	got := af.snapshot()
 	if _, ok := got.Features["polling"]; !ok {
@@ -196,9 +212,29 @@ func TestAdaptiveFetcher_SnapshotAfterCutover(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 
 	af.start()
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending initial ready signal")
+	}
 	af.cutover()
 
 	got := af.snapshot()
+	if _, ok := got.Features["streaming"]; !ok {
+		t.Fatalf("expected snapshot from streaming fetcher before polling ready")
+	}
+
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending polling ready signal")
+	}
+
+	waitFor(t, 500*time.Millisecond, func() bool {
+		return polling.startCalls.Load() == 1 && streaming.stopCalls.Load() == 1
+	}, "expected cutover to polling after polling ready")
+
+	got = af.snapshot()
 	if _, ok := got.Features["polling"]; !ok {
 		t.Fatalf("expected snapshot from polling fetcher after cutover")
 	}
@@ -225,6 +261,12 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
 	af.start()
 
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending initial ready signal")
+	}
+
 	failEvent := &failoverRequest{
 		baseFailEvent: baseFailEvent{
 			occurredAt: time.Now(),
@@ -239,8 +281,22 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 	}
 
 	waitFor(t, 500*time.Millisecond, func() bool {
-		return polling.startCalls.Load() == 1 && streaming.stopCalls.Load() == 1
-	}, "expected cutover to polling after failover signal")
+		return polling.startCalls.Load() == 1
+	}, "expected polling fetcher to start after failover signal")
+
+	if streaming.stopCalls.Load() != 0 {
+		t.Fatalf("expected streaming fetcher to keep running until polling is ready, got %d", streaming.stopCalls.Load())
+	}
+
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending polling ready signal")
+	}
+
+	waitFor(t, 500*time.Millisecond, func() bool {
+		return streaming.stopCalls.Load() == 1
+	}, "expected streaming fetcher to stop after polling ready")
 
 	select {
 	case err := <-channels.warnings:
@@ -249,5 +305,44 @@ func TestAdaptiveFetcher_FailoverSignalCutsOverAndWarns(t *testing.T) {
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatalf("expected warning to be emitted on failover")
+	}
+}
+
+func TestAdaptiveFetcher_CutoverWaitsForPollingReady(t *testing.T) {
+	streaming := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"streaming": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	polling := &fakeFetcher{
+		state: &FeatureMemoryState{
+			Features: map[string]*api.Feature{"polling": {}},
+			Segments: map[int][]api.Constraint{},
+		},
+	}
+
+	factory := makeTestFactory(streaming, polling)
+	channels := makeBaseChannels()
+
+	af := newAdaptiveFetcherWithFactory(fetcherOptions{}, channels, factory)
+	af.start()
+
+	select {
+	case af.internalReady <- true:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("timeout sending initial ready signal")
+	}
+
+	af.cutover()
+
+	if streaming.stopCalls.Load() != 0 {
+		t.Fatalf("expected streaming fetcher to continue until polling ready, got %d", streaming.stopCalls.Load())
+	}
+
+	got := af.snapshot()
+	if _, ok := got.Features["streaming"]; !ok {
+		t.Fatalf("expected snapshot from streaming fetcher before polling ready")
 	}
 }

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -233,7 +233,7 @@ func (sc *streamingFetcher) stop() {
 
 	sc.streamMu.Lock()
 	defer sc.streamMu.Unlock()
-	
+
 	if sc.streamCancel != nil {
 		sc.streamCancel()
 	}


### PR DESCRIPTION
Improves the adaptive fetcher cutover flow. The SDK now only cuts over to the next fetcher once that fetcher has signaled that its ready - in practice that it's been able to hydrate from Unleash