### PR TITLE
fix: broken events now correctly fail instead of silently continuing

### DIFF
--- a/api/delta.go
+++ b/api/delta.go
@@ -9,60 +9,83 @@ type ClientFeaturesDelta struct {
 	Events []DeltaEvent `json:"events"`
 }
 
-type DeltaEvent interface {
-	GetType() string
-	GetEventId() int
+type DeltaState struct {
+	Features map[string]*Feature
+	Segments map[int][]Constraint
 }
+
+type DeltaEvent interface {
+	Apply(state *DeltaState)
+}
+
+type BaseDeltaEvent struct {
+	Type    string `json:"type"`
+	EventId int    `json:"eventId"`
+}
+
 type FeatureUpdatedEvent struct {
-	Type    string  `json:"type"`
-	EventId int     `json:"eventId"`
+	BaseDeltaEvent
 	Feature Feature `json:"feature"`
 }
 
-func (e *FeatureUpdatedEvent) GetType() string { return e.Type }
-func (e *FeatureUpdatedEvent) GetEventId() int { return e.EventId }
-
 type FeatureRemovedEvent struct {
-	Type        string `json:"type"`
-	EventId     int    `json:"eventId"`
+	BaseDeltaEvent
 	FeatureName string `json:"featureName"`
 	Project     string `json:"project"`
 }
-
-func (e *FeatureRemovedEvent) GetType() string { return e.Type }
-func (e *FeatureRemovedEvent) GetEventId() int { return e.EventId }
-
 type SegmentUpdatedEvent struct {
-	Type    string  `json:"type"`
-	EventId int     `json:"eventId"`
+	BaseDeltaEvent
 	Segment Segment `json:"segment"`
 }
 
-func (e *SegmentUpdatedEvent) GetType() string { return e.Type }
-func (e *SegmentUpdatedEvent) GetEventId() int { return e.EventId }
-
 type SegmentRemovedEvent struct {
-	Type      string `json:"type"`
-	EventId   int    `json:"eventId"`
-	SegmentId int    `json:"segmentId"`
+	BaseDeltaEvent
+	SegmentId int `json:"segmentId"`
 }
 
-func (e *SegmentRemovedEvent) GetType() string { return e.Type }
-func (e *SegmentRemovedEvent) GetEventId() int { return e.EventId }
-
 type HydrationEvent struct {
-	Type     string    `json:"type"`
-	EventId  int       `json:"eventId"`
+	BaseDeltaEvent
 	Features []Feature `json:"features"`
 	Segments []Segment `json:"segments"`
 }
 
-func (e *HydrationEvent) GetType() string { return e.Type }
-func (e *HydrationEvent) GetEventId() int { return e.EventId }
+func (e *FeatureUpdatedEvent) Apply(state *DeltaState) {
+	state.Features[e.Feature.Name] = &e.Feature
+}
 
-// UnmarshalJSON implements custom unmarshaling for ClientFeaturesDelta
+func (e *FeatureRemovedEvent) Apply(state *DeltaState) {
+	delete(state.Features, e.FeatureName)
+}
+
+func (e *SegmentUpdatedEvent) Apply(state *DeltaState) {
+	state.Segments[e.Segment.Id] = e.Segment.Constraints
+}
+
+func (e *SegmentRemovedEvent) Apply(state *DeltaState) {
+	delete(state.Segments, e.SegmentId)
+}
+
+func (e *HydrationEvent) Apply(state *DeltaState) {
+	state.Features = make(map[string]*Feature, len(e.Features))
+	for _, f := range e.Features {
+		state.Features[f.Name] = &f
+	}
+
+	state.Segments = make(map[int][]Constraint, len(e.Segments))
+	for _, seg := range e.Segments {
+		state.Segments[seg.Id] = seg.Constraints
+	}
+}
+
+func unmarshalEvent[T DeltaEvent](raw json.RawMessage) (DeltaEvent, error) {
+	var event T
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
 func (c *ClientFeaturesDelta) UnmarshalJSON(data []byte) error {
-	// First unmarshal to get the raw events
 	var raw struct {
 		Events []json.RawMessage `json:"events"`
 	}
@@ -71,69 +94,44 @@ func (c *ClientFeaturesDelta) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Process each event
 	c.Events = make([]DeltaEvent, 0, len(raw.Events))
 
 	for _, rawEvent := range raw.Events {
-		// Determine the event type
 		var eventType struct {
 			Type string `json:"type"`
 		}
 
 		if err := json.Unmarshal(rawEvent, &eventType); err != nil {
-			continue // Skip malformed events
+			return fmt.Errorf("failed to unmarshal event type: %w", err)
 		}
 
-		var event DeltaEvent
+		var (
+			event DeltaEvent
+			err   error
+		)
 
 		switch eventType.Type {
 		case "feature-updated":
-			var e FeatureUpdatedEvent
-			if err := json.Unmarshal(rawEvent, &e); err == nil {
-				event = &e
-			}
-
+			event, err = unmarshalEvent[*FeatureUpdatedEvent](rawEvent)
 		case "feature-removed":
-			var e FeatureRemovedEvent
-			if err := json.Unmarshal(rawEvent, &e); err == nil {
-				event = &e
-			}
-
+			event, err = unmarshalEvent[*FeatureRemovedEvent](rawEvent)
 		case "segment-updated":
-			var e SegmentUpdatedEvent
-			if err := json.Unmarshal(rawEvent, &e); err == nil {
-				event = &e
-			}
-
+			event, err = unmarshalEvent[*SegmentUpdatedEvent](rawEvent)
 		case "segment-removed":
-			var e SegmentRemovedEvent
-			if err := json.Unmarshal(rawEvent, &e); err == nil {
-				event = &e
-			}
-
+			event, err = unmarshalEvent[*SegmentRemovedEvent](rawEvent)
 		case "hydration":
-			var e HydrationEvent
-			if err := json.Unmarshal(rawEvent, &e); err == nil {
-				event = &e
-			}
-
+			event, err = unmarshalEvent[*HydrationEvent](rawEvent)
 		default:
-			// Unknown event type - skip
+			// Unknown event type, this gives us a safety net for forward compatibility with new event types
 			continue
 		}
 
-		if event != nil {
-			c.Events = append(c.Events, event)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal %s event: %w", eventType.Type, err)
 		}
+
+		c.Events = append(c.Events, event)
 	}
 
 	return nil
-}
-
-func ParseDelta(data []byte) (*ClientFeaturesDelta, error) {
-	var delta ClientFeaturesDelta
-	if err := json.Unmarshal(data, &delta); err != nil {
-		return nil, fmt.Errorf("failed to parse delta: %w", err)
-	}
-	return &delta, nil
 }

--- a/api/delta_test.go
+++ b/api/delta_test.go
@@ -2,366 +2,8 @@ package api
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 )
-
-func TestParseDeltaEvent(t *testing.T) {
-	tests := []struct {
-		name      string
-		json      string
-		wantType  string
-		wantErr   bool
-		wantCount int
-	}{
-		{
-			name: "feature-updated event",
-			json: `{
-				"events": [{
-					"type": "feature-updated",
-					"eventId": 1,
-					"feature": {
-						"name": "test-feature",
-						"enabled": true,
-						"strategies": [],
-						"variants": []
-					}
-				}]
-			}`,
-			wantType:  "feature-updated",
-			wantCount: 1,
-		},
-		{
-			name: "feature-removed event",
-			json: `{
-				"events": [{
-					"type": "feature-removed",
-					"eventId": 2,
-					"featureName": "old-feature",
-					"project": "default"
-				}]
-			}`,
-			wantType:  "feature-removed",
-			wantCount: 1,
-		},
-		{
-			name: "segment-updated event",
-			json: `{
-				"events": [{
-					"type": "segment-updated",
-					"eventId": 3,
-					"segment": {
-						"id": 1,
-						"constraints": [
-							{
-								"contextName": "userId",
-								"operator": "IN",
-								"values": ["123", "456"]
-							}
-						]
-					}
-				}]
-			}`,
-			wantType:  "segment-updated",
-			wantCount: 1,
-		},
-		{
-			name: "segment-removed event",
-			json: `{
-				"events": [{
-					"type": "segment-removed",
-					"eventId": 4,
-					"segmentId": 1
-				}]
-			}`,
-			wantType:  "segment-removed",
-			wantCount: 1,
-		},
-		{
-			name: "hydration event",
-			json: `{
-				"events": [{
-					"type": "hydration",
-					"eventId": 5,
-					"features": [
-						{
-							"name": "feature-1",
-							"enabled": true,
-							"strategies": []
-						},
-						{
-							"name": "feature-2",
-							"enabled": false,
-							"strategies": []
-						}
-					],
-					"segments": [
-						{
-							"id": 1,
-							"constraints": []
-						}
-					]
-				}]
-			}`,
-			wantType:  "hydration",
-			wantCount: 1,
-		},
-		{
-			name: "multiple events",
-			json: `{
-				"events": [
-					{
-						"type": "feature-updated",
-						"eventId": 1,
-						"feature": {
-							"name": "feature-1",
-							"enabled": true
-						}
-					},
-					{
-						"type": "feature-removed",
-						"eventId": 2,
-						"featureName": "feature-2",
-						"project": "default"
-					}
-				]
-			}`,
-			wantType:  "feature-updated", // First event type
-			wantCount: 2,
-		},
-		{
-			name:      "malformed JSON",
-			json:      `{invalid json}`,
-			wantErr:   true,
-			wantCount: 0,
-		},
-		{
-			name:      "missing events array",
-			json:      `{}`,
-			wantErr:   false,
-			wantCount: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var delta ClientFeaturesDelta
-			err := json.Unmarshal([]byte(tt.json), &delta)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-
-			if err != nil {
-				return
-			}
-
-			if len(delta.Events) != tt.wantCount {
-				t.Errorf("Got %d events, want %d", len(delta.Events), tt.wantCount)
-			}
-
-			if tt.wantCount > 0 && delta.Events[0].GetType() != tt.wantType {
-				t.Errorf("First event type = %v, want %v", delta.Events[0].GetType(), tt.wantType)
-			}
-		})
-	}
-}
-
-func TestDeltaEventTypes(t *testing.T) {
-	t.Run("FeatureUpdated", func(t *testing.T) {
-		jsonStr := `{
-			"type": "feature-updated",
-			"eventId": 1,
-			"feature": {
-				"name": "test-feature",
-				"enabled": true,
-				"type": "release",
-				"description": "Test feature",
-				"strategies": [
-					{
-						"name": "default",
-						"parameters": {}
-					}
-				],
-				"variants": [
-					{
-						"name": "variant1",
-						"weight": 100
-					}
-				],
-				"dependencies": [
-					{
-						"feature": "parent-feature",
-						"enabled": true
-					}
-				]
-			}
-		}`
-
-		var event FeatureUpdatedEvent
-		err := json.Unmarshal([]byte(jsonStr), &event)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal FeatureUpdatedEvent: %v", err)
-		}
-
-		if event.Type != "feature-updated" {
-			t.Errorf("Type = %v, want feature-updated", event.Type)
-		}
-		if event.EventId != 1 {
-			t.Errorf("EventId = %v, want 1", event.EventId)
-		}
-		if event.Feature.Name != "test-feature" {
-			t.Errorf("Feature.Name = %v, want test-feature", event.Feature.Name)
-		}
-		if !event.Feature.Enabled {
-			t.Error("Feature.Enabled = false, want true")
-		}
-		if len(event.Feature.Strategies) != 1 {
-			t.Errorf("Feature.Strategies length = %v, want 1", len(event.Feature.Strategies))
-		}
-		if len(event.Feature.Variants) != 1 {
-			t.Errorf("Feature.Variants length = %v, want 1", len(event.Feature.Variants))
-		}
-		if event.Feature.Dependencies == nil || len(*event.Feature.Dependencies) != 1 {
-			t.Error("Feature.Dependencies not parsed correctly")
-		}
-	})
-
-	t.Run("FeatureRemoved", func(t *testing.T) {
-		jsonStr := `{
-			"type": "feature-removed",
-			"eventId": 2,
-			"featureName": "deprecated-feature",
-			"project": "custom-project"
-		}`
-
-		var event FeatureRemovedEvent
-		err := json.Unmarshal([]byte(jsonStr), &event)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal FeatureRemovedEvent: %v", err)
-		}
-
-		if event.Type != "feature-removed" {
-			t.Errorf("Type = %v, want feature-removed", event.Type)
-		}
-		if event.EventId != 2 {
-			t.Errorf("EventId = %v, want 2", event.EventId)
-		}
-		if event.FeatureName != "deprecated-feature" {
-			t.Errorf("FeatureName = %v, want deprecated-feature", event.FeatureName)
-		}
-		if event.Project != "custom-project" {
-			t.Errorf("Project = %v, want custom-project", event.Project)
-		}
-	})
-
-	t.Run("SegmentUpdated", func(t *testing.T) {
-		jsonStr := `{
-			"type": "segment-updated",
-			"eventId": 3,
-			"segment": {
-				"id": 42,
-				"constraints": [
-					{
-						"contextName": "environment",
-						"operator": "IN",
-						"values": ["production", "staging"]
-					}
-				]
-			}
-		}`
-
-		var event SegmentUpdatedEvent
-		err := json.Unmarshal([]byte(jsonStr), &event)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal SegmentUpdatedEvent: %v", err)
-		}
-
-		if event.Type != "segment-updated" {
-			t.Errorf("Type = %v, want segment-updated", event.Type)
-		}
-		if event.EventId != 3 {
-			t.Errorf("EventId = %v, want 3", event.EventId)
-		}
-		if event.Segment.Id != 42 {
-			t.Errorf("Segment.Id = %v, want 42", event.Segment.Id)
-		}
-		if len(event.Segment.Constraints) != 1 {
-			t.Errorf("Segment.Constraints length = %v, want 1", len(event.Segment.Constraints))
-		}
-	})
-
-	t.Run("SegmentRemoved", func(t *testing.T) {
-		jsonStr := `{
-			"type": "segment-removed",
-			"eventId": 4,
-			"segmentId": 99
-		}`
-
-		var event SegmentRemovedEvent
-		err := json.Unmarshal([]byte(jsonStr), &event)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal SegmentRemovedEvent: %v", err)
-		}
-
-		if event.Type != "segment-removed" {
-			t.Errorf("Type = %v, want segment-removed", event.Type)
-		}
-		if event.EventId != 4 {
-			t.Errorf("EventId = %v, want 4", event.EventId)
-		}
-		if event.SegmentId != 99 {
-			t.Errorf("SegmentId = %v, want 99", event.SegmentId)
-		}
-	})
-
-	t.Run("Hydration", func(t *testing.T) {
-		jsonStr := `{
-			"type": "hydration",
-			"eventId": 5,
-			"features": [
-				{
-					"name": "feature-1",
-					"enabled": true
-				},
-				{
-					"name": "feature-2",
-					"enabled": false
-				}
-			],
-			"segments": [
-				{
-					"id": 1,
-					"constraints": []
-				},
-				{
-					"id": 2,
-					"constraints": []
-				}
-			]
-		}`
-
-		var event HydrationEvent
-		err := json.Unmarshal([]byte(jsonStr), &event)
-		if err != nil {
-			t.Fatalf("Failed to unmarshal HydrationEvent: %v", err)
-		}
-
-		if event.Type != "hydration" {
-			t.Errorf("Type = %v, want hydration", event.Type)
-		}
-		if event.EventId != 5 {
-			t.Errorf("EventId = %v, want 5", event.EventId)
-		}
-		if len(event.Features) != 2 {
-			t.Errorf("Features length = %v, want 2", len(event.Features))
-		}
-		if len(event.Segments) != 2 {
-			t.Errorf("Segments length = %v, want 2", len(event.Segments))
-		}
-	})
-}
 
 func TestEventOrdering(t *testing.T) {
 	jsonStr := `{
@@ -381,117 +23,13 @@ func TestEventOrdering(t *testing.T) {
 	// Events should maintain their order as received
 	expectedIds := []int{3, 1, 2}
 	for i, event := range delta.Events {
-		if event.GetEventId() != expectedIds[i] {
-			t.Errorf("Event %d has ID %d, want %d", i, event.GetEventId(), expectedIds[i])
+		id, ok := eventID(event)
+		if !ok {
+			t.Fatalf("Event %d has unsupported type %T", i, event)
 		}
-	}
-}
-
-func TestDeltaEventInterface(t *testing.T) {
-	tests := []struct {
-		name     string
-		event    DeltaEvent
-		wantType string
-		wantId   int
-	}{
-		{
-			name:     "FeatureUpdatedEvent",
-			event:    &FeatureUpdatedEvent{Type: "feature-updated", EventId: 1},
-			wantType: "feature-updated",
-			wantId:   1,
-		},
-		{
-			name:     "FeatureRemovedEvent",
-			event:    &FeatureRemovedEvent{Type: "feature-removed", EventId: 2},
-			wantType: "feature-removed",
-			wantId:   2,
-		},
-		{
-			name:     "SegmentUpdatedEvent",
-			event:    &SegmentUpdatedEvent{Type: "segment-updated", EventId: 3},
-			wantType: "segment-updated",
-			wantId:   3,
-		},
-		{
-			name:     "SegmentRemovedEvent",
-			event:    &SegmentRemovedEvent{Type: "segment-removed", EventId: 4},
-			wantType: "segment-removed",
-			wantId:   4,
-		},
-		{
-			name:     "HydrationEvent",
-			event:    &HydrationEvent{Type: "hydration", EventId: 5},
-			wantType: "hydration",
-			wantId:   5,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.event.GetType(); got != tt.wantType {
-				t.Errorf("GetType() = %v, want %v", got, tt.wantType)
-			}
-			if got := tt.event.GetEventId(); got != tt.wantId {
-				t.Errorf("GetEventId() = %v, want %v", got, tt.wantId)
-			}
-		})
-	}
-}
-
-func TestUnmarshalDeltaEvents(t *testing.T) {
-	jsonStr := `{
-		"events": [
-			{"type": "feature-updated", "eventId": 1, "feature": {"name": "f1", "enabled": true}},
-			{"type": "feature-removed", "eventId": 2, "featureName": "f2", "project": "default"},
-			{"type": "segment-updated", "eventId": 3, "segment": {"id": 1, "constraints": []}},
-			{"type": "segment-removed", "eventId": 4, "segmentId": 2},
-			{"type": "hydration", "eventId": 5, "features": [], "segments": []}
-		]
-	}`
-
-	var delta ClientFeaturesDelta
-	err := json.Unmarshal([]byte(jsonStr), &delta)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
-	}
-
-	if len(delta.Events) != 5 {
-		t.Fatalf("Expected 5 events, got %d", len(delta.Events))
-	}
-
-	// Verify each event type was properly unmarshaled
-	expectedTypes := []string{
-		"feature-updated",
-		"feature-removed",
-		"segment-updated",
-		"segment-removed",
-		"hydration",
-	}
-
-	for i, event := range delta.Events {
-		if event.GetType() != expectedTypes[i] {
-			t.Errorf("Event %d: type = %v, want %v", i, event.GetType(), expectedTypes[i])
+		if id != expectedIds[i] {
+			t.Errorf("Event %d has ID %d, want %d", i, id, expectedIds[i])
 		}
-		if event.GetEventId() != i+1 {
-			t.Errorf("Event %d: eventId = %v, want %v", i, event.GetEventId(), i+1)
-		}
-	}
-
-	// Type assert specific events to verify fields
-	if fu, ok := delta.Events[0].(*FeatureUpdatedEvent); ok {
-		if fu.Feature.Name != "f1" {
-			t.Errorf("FeatureUpdated feature name = %v, want f1", fu.Feature.Name)
-		}
-	} else {
-		t.Error("First event should be FeatureUpdatedEvent")
-	}
-
-	if fr, ok := delta.Events[1].(*FeatureRemovedEvent); ok {
-		if fr.FeatureName != "f2" {
-			t.Errorf("FeatureRemoved feature name = %v, want f2", fr.FeatureName)
-		}
-	} else {
-		t.Error("Second event should be FeatureRemovedEvent")
 	}
 }
 
@@ -528,7 +66,10 @@ func TestDeltaWithUnknownEventType(t *testing.T) {
 	// Should still process known events
 	knownEvents := 0
 	for _, event := range delta.Events {
-		if event != nil && event.GetType() == "feature-updated" {
+		if event == nil {
+			continue
+		}
+		if _, ok := event.(*FeatureUpdatedEvent); ok {
 			knownEvents++
 		}
 	}
@@ -538,32 +79,113 @@ func TestDeltaWithUnknownEventType(t *testing.T) {
 	}
 }
 
-func TestDeltaEventComparison(t *testing.T) {
-	event1 := &FeatureUpdatedEvent{
-		Type:    "feature-updated",
-		EventId: 1,
-		Feature: Feature{Name: "test"},
+func eventID(event DeltaEvent) (int, bool) {
+	switch e := event.(type) {
+	case *FeatureUpdatedEvent:
+		return e.EventId, true
+	case *FeatureRemovedEvent:
+		return e.EventId, true
+	case *SegmentUpdatedEvent:
+		return e.EventId, true
+	case *SegmentRemovedEvent:
+		return e.EventId, true
+	case *HydrationEvent:
+		return e.EventId, true
+	default:
+		return 0, false
+	}
+}
+
+func TestApplyFeatureUpdatedEvent(t *testing.T) {
+	state := &DeltaState{
+		Features: map[string]*Feature{},
+		Segments: map[int][]Constraint{},
+	}
+	event := &FeatureUpdatedEvent{
+		Feature: Feature{Name: "flag-a", Enabled: true},
 	}
 
-	event2 := &FeatureUpdatedEvent{
-		Type:    "feature-updated",
-		EventId: 1,
-		Feature: Feature{Name: "test"},
+	event.Apply(state)
+
+	if got, ok := state.Features["flag-a"]; !ok || got == nil || !got.Enabled {
+		t.Fatalf("expected feature to be applied and enabled")
+	}
+}
+
+func TestApplyFeatureRemovedEvent(t *testing.T) {
+	state := &DeltaState{
+		Features: map[string]*Feature{
+			"flag-a": {Name: "flag-a", Enabled: true},
+		},
+		Segments: map[int][]Constraint{},
+	}
+	event := &FeatureRemovedEvent{FeatureName: "flag-a"}
+
+	event.Apply(state)
+
+	if _, ok := state.Features["flag-a"]; ok {
+		t.Fatalf("expected feature to be removed")
+	}
+}
+
+func TestApplySegmentUpdatedEvent(t *testing.T) {
+	state := &DeltaState{
+		Features: map[string]*Feature{},
+		Segments: map[int][]Constraint{},
+	}
+	event := &SegmentUpdatedEvent{
+		Segment: Segment{Id: 1, Constraints: []Constraint{{ContextName: "userId", Operator: "IN", Values: []string{"123"}}}},
 	}
 
-	event3 := &FeatureUpdatedEvent{
-		Type:    "feature-updated",
-		EventId: 2,
-		Feature: Feature{Name: "test"},
+	event.Apply(state)
+
+	if got, ok := state.Segments[1]; !ok || len(got) != 1 {
+		t.Fatalf("expected segment constraints to be applied")
+	}
+}
+
+func TestApplySegmentRemovedEvent(t *testing.T) {
+	state := &DeltaState{
+		Features: map[string]*Feature{},
+		Segments: map[int][]Constraint{2: {{ContextName: "userId", Operator: "IN", Values: []string{"123"}}}},
+	}
+	event := &SegmentRemovedEvent{SegmentId: 2}
+
+	event.Apply(state)
+
+	if _, ok := state.Segments[2]; ok {
+		t.Fatalf("expected segment to be removed")
+	}
+}
+
+func TestApplyHydrationEvent(t *testing.T) {
+	state := &DeltaState{
+		Features: map[string]*Feature{
+			"old": {Name: "old", Enabled: true},
+		},
+		Segments: map[int][]Constraint{99: {{ContextName: "userId", Operator: "IN", Values: []string{"old"}}}},
+	}
+	event := &HydrationEvent{
+		Features: []Feature{
+			{Name: "new", Enabled: false},
+		},
+		Segments: []Segment{
+			{Id: 3, Constraints: []Constraint{{ContextName: "sessionId", Operator: "IN", Values: []string{"abc"}}}},
+		},
 	}
 
-	// Same event ID and content
-	if !reflect.DeepEqual(event1, event2) {
-		t.Error("Expected events with same ID and content to be equal")
-	}
+	event.Apply(state)
 
-	// Different event ID
-	if reflect.DeepEqual(event1, event3) {
-		t.Error("Expected events with different IDs to be different")
+	if len(state.Features) != 1 {
+		t.Fatalf("expected features to be replaced on hydration")
+	}
+	if _, ok := state.Features["new"]; !ok {
+		t.Fatalf("expected hydrated feature to be present")
+	}
+	if len(state.Segments) != 1 {
+		t.Fatalf("expected segments to be replaced on hydration")
+	}
+	if _, ok := state.Segments[3]; !ok {
+		t.Fatalf("expected hydrated segment to be present")
 	}
 }

--- a/delta_processor.go
+++ b/delta_processor.go
@@ -59,41 +59,18 @@ func (dp *deltaProcessor) process(delta *api.ClientFeaturesDelta) (*api.FeatureR
 		segMap[id] = constraints
 	}
 
+	deltaState := &api.DeltaState{
+		Features: featMap,
+		Segments: segMap,
+	}
+
 	for _, event := range delta.Events {
-		switch e := event.(type) {
-
-		case *api.FeatureUpdatedEvent:
-			featMap[e.Feature.Name] = &e.Feature
-
-		case *api.FeatureRemovedEvent:
-			delete(featMap, e.FeatureName)
-
-		case *api.SegmentUpdatedEvent:
-			segMap[e.Segment.Id] = e.Segment.Constraints
-
-		case *api.SegmentRemovedEvent:
-			delete(segMap, e.SegmentId)
-
-		case *api.HydrationEvent:
-			featMap = make(map[string]*api.Feature, len(e.Features))
-			for _, f := range e.Features {
-				featMap[f.Name] = &f
-			}
-
-			segMap = make(map[int][]api.Constraint, len(e.Segments))
-			for _, seg := range e.Segments {
-				segMap[seg.Id] = seg.Constraints
-			}
-
-		default:
-			// Unknown event type - log but don't fail
-			// This allows forward compatibility with new event types
-		}
+		event.Apply(deltaState)
 	}
 
 	newState := &FeatureMemoryState{
-		Features: featMap,
-		Segments: segMap,
+		Features: deltaState.Features,
+		Segments: deltaState.Segments,
 	}
 
 	dp.featureState.Store(newState)

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -2,6 +2,7 @@ package unleash
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -197,12 +198,13 @@ func (sc *streamingFetcher) notifyUpdate() {
 
 func (sc *streamingFetcher) handleDomainEvent(event eventsource.Event) error {
 	eventData := []byte(event.Data())
-	delta, err := api.ParseDelta(eventData)
-	if err != nil {
-		return fmt.Errorf("failed to parse event: %w", err)
+
+	var delta api.ClientFeaturesDelta
+	if err := json.Unmarshal(eventData, &delta); err != nil {
+		return fmt.Errorf("failed to parse delta: %w", err)
 	}
 
-	backupState, err := sc.deltaProcessor.process(delta)
+	backupState, err := sc.deltaProcessor.process(&delta)
 
 	if err != nil {
 		return fmt.Errorf("failed to process delta: %w", err)


### PR DESCRIPTION
This forces events that are corrupted to correctly fail in the delta parse code. Corrupted means one of the following is true:

- The SSE envelope is valid but the content is not valid JSON
- The SSE envelope is valid and the outer contents are valid JSON but the inner packet of the event data is not valid JSON
- The SSE envelope is valid and the content is JSON but the packet cannot be parsed as the type that `Type` specifies. This only applies if that type is one of the 5 known event types

This does not reject well formed events that are unrecognized - this gives us a layer of forwards compatibility if we decide to add new events in a backwards compatible way

Does a bunch of clean ups to improve the flow and move us away from the TypeScript in Go patterns that we were previously using 