### PR TITLE
feat: make delta api work

### DIFF
--- a/api/api_response.go
+++ b/api/api_response.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type ResponseKind int
+
+const (
+	FullResponse = iota
+	DeltaResponse
+)
+
+type ApiResponse struct {
+	Full  *FeatureResponse
+	Delta *ClientFeaturesDelta
+	Kind  ResponseKind
+}
+
+func (r *ApiResponse) IsFullResponse() bool {
+	return r.Kind == FullResponse
+}
+
+func (r *ApiResponse) IsDeltaResponse() bool {
+	return r.Kind == DeltaResponse
+}
+
+func (r *ApiResponse) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if events, ok := raw["events"]; ok && events != nil {
+		var delta ClientFeaturesDelta
+		if err := json.Unmarshal(data, &delta); err != nil {
+			return err
+		}
+		r.Delta = &delta
+		r.Full = nil
+		r.Kind = DeltaResponse
+		return nil
+	}
+
+	if features, ok := raw["features"]; ok && features != nil {
+		var full FeatureResponse
+		if err := json.Unmarshal(data, &full); err != nil {
+			return err
+		}
+		r.Full = &full
+		r.Delta = nil
+		r.Kind = FullResponse
+		return nil
+	}
+
+	return fmt.Errorf("unknown response format: %s", string(data))
+}

--- a/delta_processor.go
+++ b/delta_processor.go
@@ -35,11 +35,33 @@ func newDeltaProcessor(baseState *api.FeatureResponse) *deltaProcessor {
 	return deltaProcessor
 }
 
+func (dp *deltaProcessor) updateFromApiResponse(api *api.ApiResponse) (*api.FeatureResponse, error) {
+	if api.IsFullResponse() {
+		return dp.updateFromFullResponse(api.Full)
+	}
+
+	if api.IsDeltaResponse() {
+		return dp.updateFromDelta(api.Delta)
+	}
+
+	return nil, fmt.Errorf("unknown API response type")
+}
+
+func (dp *deltaProcessor) updateFromFullResponse(full *api.FeatureResponse) (*api.FeatureResponse, error) {
+	newState := &FeatureMemoryState{
+		Features: full.FeatureMap(),
+		Segments: full.SegmentsMap(),
+	}
+
+	dp.featureState.Store(newState)
+	return full, nil
+}
+
 // It's hard to make this both concurrency safe and atomic for both readers and writes. To build our new state we need
 // to hold a lock over the entire process to prevent internal races setting the final state out of order.
 // However, once we have built the new state we can atomically swap it. This gives us mutex locked writes but
 // lock free reads via snapshot()
-func (dp *deltaProcessor) process(delta *api.ClientFeaturesDelta) (*api.FeatureResponse, error) {
+func (dp *deltaProcessor) updateFromDelta(delta *api.ClientFeaturesDelta) (*api.FeatureResponse, error) {
 	if delta == nil {
 		return nil, fmt.Errorf("delta is nil")
 	}

--- a/polling_fetcher.go
+++ b/polling_fetcher.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v6/api"
@@ -30,18 +29,18 @@ type togglerFetcher interface {
 type pollingFetcher struct {
 	fetcherChannels
 	sync.RWMutex
-	options       fetcherOptions
-	etag          string
-	close         chan struct{}
-	closed        chan struct{}
-	ctx           context.Context
-	cancel        func()
-	isReady       bool
-	refreshTicker *time.Ticker
-	errors        float64
-	maxSkips      float64
-	skips         float64
-	featureState  atomic.Value // this should always hold an instance of *FeatureMemoryState
+	options        fetcherOptions
+	etag           string
+	close          chan struct{}
+	closed         chan struct{}
+	ctx            context.Context
+	cancel         func()
+	isReady        bool
+	refreshTicker  *time.Ticker
+	errors         float64
+	maxSkips       float64
+	skips          float64
+	deltaProcessor *deltaProcessor
 }
 
 func newPollingFetcher(options fetcherOptions, channels fetcherChannels) *pollingFetcher {
@@ -63,29 +62,23 @@ func newPollingFetcher(options fetcherOptions, channels fetcherChannels) *pollin
 		f.options.httpClient = http.DefaultClient
 	}
 
-	if loadedState, err := f.options.storage.Load(); err == nil && loadedState != nil {
-		f.updateState(loadedState)
+	var apiResponse *api.FeatureResponse
+
+	if loadedState, err := options.storage.Load(); err == nil && loadedState != nil {
+		apiResponse = loadedState
 	} else {
-		f.featureState.Store(&FeatureMemoryState{
-			Features: make(map[string]*api.Feature),
-			Segments: make(map[int][]api.Constraint),
-		})
+		apiResponse = &api.FeatureResponse{
+			Features: []api.Feature{},
+			Segments: []api.Segment{},
+		}
 	}
+
+	f.deltaProcessor = newDeltaProcessor(apiResponse)
 
 	return f
 }
 
-func (r *pollingFetcher) updateState(features *api.FeatureResponse) {
-	state := &FeatureMemoryState{
-		Features: features.FeatureMap(),
-		Segments: features.SegmentsMap(),
-	}
-
-	r.featureState.Store(state)
-}
-
 func (r *pollingFetcher) saveState(features *api.FeatureResponse) error {
-	r.updateState(features)
 	return r.options.storage.Persist(features)
 }
 
@@ -184,7 +177,7 @@ func (r *pollingFetcher) fetch() (bool, error) {
 		return false, err
 	}
 
-	var featureResp api.FeatureResponse
+	var featureResp api.ApiResponse
 	dec := json.NewDecoder(resp.Body)
 	if err := dec.Decode(&featureResp); err != nil {
 		return false, err
@@ -192,7 +185,14 @@ func (r *pollingFetcher) fetch() (bool, error) {
 
 	r.Lock()
 	r.etag = resp.Header.Get("Etag")
-	r.saveState(&featureResp)
+
+	apiResponse, err := r.deltaProcessor.updateFromApiResponse(&featureResp)
+	if err != nil {
+		r.Unlock()
+		return false, err
+	}
+	r.saveState(apiResponse)
+
 	r.successfulFetch()
 	r.Unlock()
 	return true, nil
@@ -214,16 +214,7 @@ func (r *pollingFetcher) statusIsOK(resp *http.Response) error {
 }
 
 func (r *pollingFetcher) snapshot() *FeatureMemoryState {
-	v := r.featureState.Load()
-	if v == nil {
-		empty := &FeatureMemoryState{
-			Features: make(map[string]*api.Feature),
-			Segments: make(map[int][]api.Constraint),
-		}
-		r.featureState.Store(empty)
-		return empty
-	}
-	return v.(*FeatureMemoryState)
+	return r.deltaProcessor.snapshot()
 }
 
 func (r *pollingFetcher) stop() {

--- a/spec_test.go
+++ b/spec_test.go
@@ -25,13 +25,6 @@ const specFolder = "./testdata/client-specification/specifications"
 var specIndex = filepath.Join(specFolder, "index.json")
 var specNotImplemented = []string{""}
 
-type TestState struct {
-	Version  int               `json:"version"`
-	Features []api.Feature     `json:"features"`
-	Segments []api.Segment     `json:"segments"`
-	Events   []json.RawMessage `json:"events"`
-}
-
 type TestCase struct {
 	Description    string          `json:"description"`
 	Context        context.Context `json:"context"`
@@ -106,120 +99,27 @@ func (vtc VariantTestCase) RunWithClient(client *Client) func(*testing.T) {
 
 type TestDefinition struct {
 	Name         string            `json:"name"`
-	State        TestState         `json:"state"`
+	State        json.RawMessage   `json:"state"`
 	Tests        []TestCase        `json:"tests"`
 	VariantTests []VariantTestCase `json:"variantTests"`
 }
 
 func (td TestDefinition) Mock(listener interface{}) (*Client, error) {
-	// Process events if present (for delta API tests)
-	features := td.State.Features
-	segments := td.State.Segments
-
-	if len(td.State.Events) > 0 {
-		// Process delta events to build features and segments
-		features, segments = td.processDeltaEvents()
-	}
-
 	gock.New(mockHost).
 		Post("/client/register").
 		Reply(200)
+
 	gock.New(mockHost).
 		Get("/client/features").
 		Reply(200).
-		JSON(api.FeatureResponse{
-			Response: api.Response{
-				Version: td.State.Version,
-			},
-			Features: features,
-			Segments: segments,
-		})
+		SetHeader("Content-Type", "application/json").
+		BodyString(string(td.State))
 
 	return NewClient(
 		WithUrl(mockHost),
 		WithAppName("clientSpecificationTest"),
 		WithListener(listener),
 	)
-}
-
-func (td TestDefinition) processDeltaEvents() ([]api.Feature, []api.Segment) {
-	features := make(map[string]api.Feature)
-	segments := make(map[int]api.Segment)
-
-	// Process each event
-	for _, eventRaw := range td.State.Events {
-		var eventType struct {
-			Type string `json:"type"`
-		}
-		if err := json.Unmarshal(eventRaw, &eventType); err != nil {
-			continue
-		}
-
-		switch eventType.Type {
-		case "hydration":
-			var hydration struct {
-				Features []api.Feature `json:"features"`
-				Segments []api.Segment `json:"segments"`
-			}
-			if err := json.Unmarshal(eventRaw, &hydration); err == nil {
-				// Reset state for hydration
-				features = make(map[string]api.Feature)
-				segments = make(map[int]api.Segment)
-
-				for _, f := range hydration.Features {
-					features[f.Name] = f
-				}
-				for _, s := range hydration.Segments {
-					segments[s.Id] = s
-				}
-			}
-
-		case "feature-updated":
-			var update struct {
-				Feature api.Feature `json:"feature"`
-			}
-			if err := json.Unmarshal(eventRaw, &update); err == nil {
-				features[update.Feature.Name] = update.Feature
-			}
-
-		case "feature-removed":
-			var removal struct {
-				FeatureName string `json:"featureName"`
-			}
-			if err := json.Unmarshal(eventRaw, &removal); err == nil {
-				delete(features, removal.FeatureName)
-			}
-
-		case "segment-updated":
-			var update struct {
-				Segment api.Segment `json:"segment"`
-			}
-			if err := json.Unmarshal(eventRaw, &update); err == nil {
-				segments[update.Segment.Id] = update.Segment
-			}
-
-		case "segment-removed":
-			var removal struct {
-				SegmentId int `json:"segmentId"`
-			}
-			if err := json.Unmarshal(eventRaw, &removal); err == nil {
-				delete(segments, removal.SegmentId)
-			}
-		}
-	}
-
-	// Convert maps to slices
-	var featureList []api.Feature
-	for _, f := range features {
-		featureList = append(featureList, f)
-	}
-
-	var segmentList []api.Segment
-	for _, s := range segments {
-		segmentList = append(segmentList, s)
-	}
-
-	return featureList, segmentList
 }
 
 func (td TestDefinition) Unmock() {

--- a/streaming_delta_integration_test.go
+++ b/streaming_delta_integration_test.go
@@ -34,7 +34,7 @@ func TestStreamingDeltaIntegration(t *testing.T) {
 			t.Fatalf("Failed to unmarshal hydration: %v", err)
 		}
 
-		_, err = processor.process(&delta)
+		_, err = processor.updateFromDelta(&delta)
 		snapshot := processor.snapshot()
 		if err != nil {
 			t.Fatalf("Failed to process hydration: %v", err)
@@ -97,7 +97,7 @@ func TestStreamingDeltaIntegration(t *testing.T) {
 			t.Fatalf("Failed to unmarshal update: %v", err)
 		}
 
-		_, err = processor.process(&delta)
+		_, err = processor.updateFromDelta(&delta)
 		if err != nil {
 			t.Fatalf("Failed to process update: %v", err)
 		}
@@ -157,7 +157,7 @@ func TestStreamingDelta_MultipleDeltaEvents(t *testing.T) {
 	err := json.Unmarshal([]byte(hydrationJSON), &hydrationDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&hydrationDelta)
+	_, err = processor.updateFromDelta(&hydrationDelta)
 	assert.NoError(t, err)
 	snapshot := processor.snapshot()
 
@@ -202,7 +202,7 @@ func TestStreamingDelta_MultipleDeltaEvents(t *testing.T) {
 	err = json.Unmarshal([]byte(updatesJSON), &updatesDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&updatesDelta)
+	_, err = processor.updateFromDelta(&updatesDelta)
 	assert.NoError(t, err)
 	snapshot = processor.snapshot()
 
@@ -263,7 +263,7 @@ func TestStreamingDelta_SegmentUpdates(t *testing.T) {
 	err := json.Unmarshal([]byte(hydrationJSON), &hydrationDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&hydrationDelta)
+	_, err = processor.updateFromDelta(&hydrationDelta)
 	assert.NoError(t, err)
 
 	snapshot := processor.snapshot()
@@ -295,7 +295,7 @@ func TestStreamingDelta_SegmentUpdates(t *testing.T) {
 	err = json.Unmarshal([]byte(segmentUpdateJSON), &segmentUpdateDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&segmentUpdateDelta)
+	_, err = processor.updateFromDelta(&segmentUpdateDelta)
 	assert.NoError(t, err)
 
 	snapshot = processor.snapshot()
@@ -343,7 +343,7 @@ func TestStreamingDelta_SegmentUpdates(t *testing.T) {
 	err = json.Unmarshal([]byte(multiSegmentUpdateJSON), &multiSegmentDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&multiSegmentDelta)
+	_, err = processor.updateFromDelta(&multiSegmentDelta)
 	assert.NoError(t, err)
 
 	snapshot = processor.snapshot()
@@ -389,7 +389,7 @@ func TestStreamingDelta_ErrorHandling(t *testing.T) {
 	err := json.Unmarshal([]byte(validHydrationJSON), &validDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&validDelta)
+	_, err = processor.updateFromDelta(&validDelta)
 	assert.NoError(t, err)
 
 	snapshot := processor.snapshot()
@@ -400,7 +400,7 @@ func TestStreamingDelta_ErrorHandling(t *testing.T) {
 	}
 
 	// Try to process nil delta (should handle gracefully)
-	_, err = processor.process(nil)
+	_, err = processor.updateFromDelta(nil)
 	if err == nil {
 		t.Error("Processing nil delta should return an error")
 	}
@@ -417,7 +417,7 @@ func TestStreamingDelta_ErrorHandling(t *testing.T) {
 	err = json.Unmarshal([]byte(unknownEventJSON), &unknownDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&unknownDelta)
+	_, err = processor.updateFromDelta(&unknownDelta)
 	// Should not error, just ignore unknown event
 	assert.NoError(t, err)
 
@@ -436,7 +436,7 @@ func TestStreamingDelta_ErrorHandling(t *testing.T) {
 	err = json.Unmarshal([]byte(validUpdateJSON), &validUpdateDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&validUpdateDelta)
+	_, err = processor.updateFromDelta(&validUpdateDelta)
 	assert.NoError(t, err)
 
 	snapshot = processor.snapshot()
@@ -493,7 +493,7 @@ func TestStreamingDelta_ConstraintEvaluation(t *testing.T) {
 	err := json.Unmarshal([]byte(hydrationJSON), &hydrationDelta)
 	assert.NoError(t, err)
 
-	_, err = processor.process(&hydrationDelta)
+	_, err = processor.updateFromDelta(&hydrationDelta)
 	assert.NoError(t, err)
 
 	snapshot := processor.snapshot()

--- a/streaming_fetcher.go
+++ b/streaming_fetcher.go
@@ -204,7 +204,7 @@ func (sc *streamingFetcher) handleDomainEvent(event eventsource.Event) error {
 		return fmt.Errorf("failed to parse delta: %w", err)
 	}
 
-	backupState, err := sc.deltaProcessor.process(&delta)
+	backupState, err := sc.deltaProcessor.updateFromDelta(&delta)
 
 	if err != nil {
 		return fmt.Errorf("failed to process delta: %w", err)


### PR DESCRIPTION
This is actually primarily a patch to make the client specification tests work against production code for streaming/delta events - the spec tests for delta are intentionally built so that you can't make them pass without correctly implementing delta API. This patch makes delta API work and removes the hacks that were allowing the spec tests to pass.

We now accept a union type on the API of either a delta or a full response and then just hand that off to delta processor to make a decision around either applying the full update or layering in the events.

Delta processor now needs a rename, done in #266 