### PR TITLE
feat: add WithDisablePolling and WithSynchronousFetchOnInitialisation options

### DIFF
--- a/client.go
+++ b/client.go
@@ -199,16 +199,18 @@ func NewClient(options ...ConfigOption) (*Client, error) {
 
 	uc.repository = newRepository(
 		repositoryOptions{
-			backupPath:      uc.options.backupPath,
-			url:             *parsedUrl,
-			appName:         uc.options.appName,
-			projectName:     uc.options.projectName,
-			instanceId:      uc.options.instanceId,
-			refreshInterval: uc.options.refreshInterval,
-			storage:         uc.options.storage,
-			httpClient:      uc.options.httpClient,
-			headers:         headers,
-			isStreaming:     uc.options.IsStreamingMode(),
+			backupPath:       uc.options.backupPath,
+			url:              *parsedUrl,
+			appName:          uc.options.appName,
+			projectName:      uc.options.projectName,
+			instanceId:       uc.options.instanceId,
+			refreshInterval:  uc.options.refreshInterval,
+			disablePolling:   uc.options.disablePolling,
+			synchronousFetch: uc.options.synchronousFetch,
+			storage:          uc.options.storage,
+			httpClient:       uc.options.httpClient,
+			headers:          headers,
+			isStreaming:      uc.options.IsStreamingMode(),
 		},
 		repositoryChannels{
 			errorChannels: errChannels,

--- a/client_test.go
+++ b/client_test.go
@@ -1564,6 +1564,7 @@ func TestClient_DisablePollingUsesBootstrappedFeatures(t *testing.T) {
 		WithInstanceId(mockInstanceId),
 		WithDisableMetrics(true),
 		WithDisablePolling(true),
+		WithBackupPath(t.TempDir()),
 		WithStorage(&BootstrapStorage{Reader: bootstrap}),
 		WithRefreshInterval(time.Millisecond),
 	)
@@ -1711,5 +1712,59 @@ func TestClient_SynchronousFetchWithPollingContinues(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	assert.Greater(atomic.LoadInt32(&featuresCalls), int32(1), "expected continued polling after sync fetch")
 
+	assert.Nil(client.Close())
+}
+
+func TestClient_SynchronousFetchFailsPollingRecoversImmediately(t *testing.T) {
+	assert := assert.New(t)
+	var featuresCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.Method + " " + req.URL.Path {
+		case "GET /client/features":
+			n := atomic.AddInt32(&featuresCalls, 1)
+			if n == 1 {
+				rw.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			rw.WriteHeader(http.StatusOK)
+			writeJSON(rw, api.FeatureResponse{
+				Features: []api.Feature{
+					{Name: "recovered-feature", Enabled: true, Strategies: []api.Strategy{{Name: "default"}}},
+				},
+			})
+		default:
+			t.Fatalf("Unexpected request: %+v", req)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithUrl(srv.URL),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithSynchronousFetchOnInitialisation(true),
+		WithRefreshInterval(200*time.Millisecond),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	assert.False(client.IsEnabled("recovered-feature"), "feature not available after failed sync fetch")
+
+	// The polling loop should retry immediately (not wait a full 200ms interval) because
+	// synchronousFetch failed. WaitForReady must unblock well before the interval expires.
+	done := make(chan struct{})
+	go func() {
+		client.WaitForReady()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WaitForReady blocked for more than 500ms — polling loop did not retry immediately after failed sync fetch")
+	}
+
+	assert.True(client.IsEnabled("recovered-feature"), "feature available after polling recovery")
 	assert.Nil(client.Close())
 }

--- a/client_test.go
+++ b/client_test.go
@@ -1,17 +1,19 @@
 package unleash
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/Unleash/unleash-go-sdk/v5/api"
 	"github.com/Unleash/unleash-go-sdk/v5/context"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
-	"testing"
-
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClientWithoutListener(t *testing.T) {
@@ -1495,4 +1497,219 @@ func TestConnectionAndIntervalHeadersAndBody(t *testing.T) {
 	err = client.Close()
 
 	assert.True(gock.IsDone(), "there should be no more mocks")
+}
+
+func TestClient_DisablePollingDoesNotFetchFeatures(t *testing.T) {
+	assert := assert.New(t)
+	var featuresCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.Method + " " + req.URL.Path {
+		case "GET /client/features":
+			atomic.AddInt32(&featuresCalls, 1)
+			rw.WriteHeader(http.StatusOK)
+			writeJSON(rw, api.FeatureResponse{})
+		default:
+			t.Fatalf("Unexpected request: %+v", req)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithUrl(srv.URL),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithDisablePolling(true),
+		WithRefreshInterval(time.Millisecond),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	time.Sleep(25 * time.Millisecond)
+	assert.Equal(int32(0), atomic.LoadInt32(&featuresCalls))
+	assert.Nil(client.Close())
+}
+
+func TestClient_DisablePollingUsesBootstrappedFeatures(t *testing.T) {
+	assert := assert.New(t)
+	var featuresCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method == "GET" && req.URL.Path == "/client/features" {
+			atomic.AddInt32(&featuresCalls, 1)
+		}
+		t.Fatalf("Unexpected request: %+v", req)
+	}))
+	defer srv.Close()
+
+	bootstrap := bytes.NewBufferString(`{
+		"version": 2,
+		"features": [
+			{
+				"name": "bootstrapped-feature",
+				"enabled": true,
+				"strategies": [
+					{
+						"name": "default"
+					}
+				],
+				"variants": []
+			}
+		]
+	}`)
+
+	client, err := NewClient(
+		WithUrl(srv.URL),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithDisablePolling(true),
+		WithStorage(&BootstrapStorage{Reader: bootstrap}),
+		WithRefreshInterval(time.Millisecond),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	assert.True(client.IsEnabled("bootstrapped-feature"))
+	time.Sleep(25 * time.Millisecond)
+	assert.Equal(int32(0), atomic.LoadInt32(&featuresCalls))
+	assert.Nil(client.Close())
+}
+
+func TestClient_DisablePollingAllowsSynchronousInitialFetch(t *testing.T) {
+	assert := assert.New(t)
+	var featuresCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.Method + " " + req.URL.Path {
+		case "GET /client/features":
+			atomic.AddInt32(&featuresCalls, 1)
+			rw.WriteHeader(http.StatusOK)
+			writeJSON(rw, api.FeatureResponse{
+				Features: []api.Feature{
+					{
+						Name:    "synchronously-fetched-feature",
+						Enabled: true,
+						Strategies: []api.Strategy{
+							{
+								Name: "default",
+							},
+						},
+					},
+				},
+			})
+		default:
+			t.Fatalf("Unexpected request: %+v", req)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithUrl(srv.URL),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithDisablePolling(true),
+		WithSynchronousFetchOnInitialisation(true),
+		WithRefreshInterval(time.Millisecond),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	assert.True(client.IsEnabled("synchronously-fetched-feature"))
+	time.Sleep(25 * time.Millisecond)
+	assert.Equal(int32(1), atomic.LoadInt32(&featuresCalls))
+	assert.Nil(client.Close())
+}
+
+func TestClient_DisablePollingReadyFiresImmediately(t *testing.T) {
+	assert := assert.New(t)
+
+	client, err := NewClient(
+		WithUrl("http://localhost:1"),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithDisablePolling(true),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	done := make(chan struct{})
+	go func() {
+		client.WaitForReady()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.NewTimer(500 * time.Millisecond).C:
+		t.Fatal("WaitForReady() did not return immediately in static mode")
+	}
+	assert.Nil(client.Close())
+}
+
+func TestClient_DisablePollingCloseDoesNotDeadlock(t *testing.T) {
+	assert := assert.New(t)
+
+	client, err := NewClient(
+		WithUrl("http://localhost:1"),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithDisablePolling(true),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	done := make(chan struct{})
+	go func() {
+		client.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.NewTimer(2 * time.Second).C:
+		t.Fatal("Close() deadlocked in static mode")
+	}
+}
+
+func TestClient_SynchronousFetchWithPollingContinues(t *testing.T) {
+	assert := assert.New(t)
+	var featuresCalls int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		switch req.Method + " " + req.URL.Path {
+		case "GET /client/features":
+			atomic.AddInt32(&featuresCalls, 1)
+			rw.WriteHeader(http.StatusOK)
+			writeJSON(rw, api.FeatureResponse{
+				Features: []api.Feature{
+					{
+						Name:    "sync-polled-feature",
+						Enabled: true,
+						Strategies: []api.Strategy{
+							{Name: "default"},
+						},
+					},
+				},
+			})
+		default:
+			t.Fatalf("Unexpected request: %+v", req)
+		}
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(
+		WithUrl(srv.URL),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+		WithDisableMetrics(true),
+		WithSynchronousFetchOnInitialisation(true),
+		WithRefreshInterval(10*time.Millisecond),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	assert.True(client.IsEnabled("sync-polled-feature"))
+	assert.GreaterOrEqual(atomic.LoadInt32(&featuresCalls), int32(1), "expected at least one fetch on init")
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Greater(atomic.LoadInt32(&featuresCalls), int32(1), "expected continued polling after sync fetch")
+
+	assert.Nil(client.Close())
 }

--- a/config.go
+++ b/config.go
@@ -19,6 +19,8 @@ type configOption struct {
 	projectName      string
 	refreshInterval  time.Duration
 	metricsInterval  time.Duration
+	disablePolling   bool
+	synchronousFetch bool
 	disableMetrics   bool
 	backupPath       string
 	strategies       []strategy.Strategy
@@ -76,6 +78,22 @@ func WithUrl(url string) ConfigOption {
 func WithRefreshInterval(refreshInterval time.Duration) ConfigOption {
 	return func(o *configOption) {
 		o.refreshInterval = refreshInterval
+	}
+}
+
+// WithDisablePolling specifies whether the client should stop polling the
+// unleash server for feature toggles.
+func WithDisablePolling(disablePolling bool) ConfigOption {
+	return func(o *configOption) {
+		o.disablePolling = disablePolling
+	}
+}
+
+// WithSynchronousFetchOnInitialisation specifies whether the client should
+// synchronously fetch feature toggles from the unleash server on initialisation.
+func WithSynchronousFetchOnInitialisation(synchronousFetch bool) ConfigOption {
+	return func(o *configOption) {
+		o.synchronousFetch = synchronousFetch
 	}
 }
 
@@ -260,16 +278,18 @@ func WithVariantFallbackFunc(variantFallbackFunc VariantFallbackFunc) VariantOpt
 }
 
 type repositoryOptions struct {
-	appName         string
-	instanceId      string
-	projectName     string
-	url             url.URL
-	backupPath      string
-	refreshInterval time.Duration
-	storage         Storage
-	httpClient     	*http.Client
-	headers         http.Header
-	isStreaming     bool
+	appName          string
+	instanceId       string
+	projectName      string
+	url              url.URL
+	backupPath       string
+	refreshInterval  time.Duration
+	disablePolling   bool
+	synchronousFetch bool
+	storage          Storage
+	httpClient       *http.Client
+	headers          http.Header
+	isStreaming      bool
 }
 
 type metricsOptions struct {

--- a/repository.go
+++ b/repository.go
@@ -139,8 +139,9 @@ func (r *repository) sync() {
 		}
 	}
 
-	// Use polling if not streaming
-	if !isStreaming && !r.options.synchronousFetch {
+	// Skip the leading fetch only when synchronousFetch already succeeded in newRepository().
+	// If the synchronous fetch failed, retry immediately rather than waiting a full interval.
+	if !isStreaming && (!r.options.synchronousFetch || !r.isReady) {
 		r.fetchAndReportError()
 	}
 

--- a/repository.go
+++ b/repository.go
@@ -44,9 +44,6 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 	repo := &repository{
 		options:            options,
 		repositoryChannels: channels,
-		close:              make(chan struct{}),
-		closed:             make(chan struct{}),
-		refreshTicker:      time.NewTicker(options.refreshInterval),
 		segments:           map[int][]api.Constraint{},
 		errors:             0,
 		maxSkips:           10,
@@ -68,7 +65,7 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 	repo.options.storage.Init(options.backupPath, options.appName)
 	// In the future, remove the dependency of the repository and just pass in the storage
 	repo.deltaProcessor = newDeltaProcessor(repo.options.storage, repo, channels)
-	
+
 	if repo.isStreaming {
 		repo.streamingClient = newStreamingClient(
 			options,
@@ -77,7 +74,24 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 		)
 	}
 
-	go repo.sync()
+	if !repo.isStreaming && repo.options.synchronousFetch {
+		repo.fetchAndReportError()
+	}
+
+	// Static mode: both polling and streaming are disabled. Signal ready with
+	// whatever backup state was loaded during Init() and skip the sync goroutine
+	// entirely — there is no async work to manage.
+	if repo.options.disablePolling && !repo.isStreaming {
+		if !repo.isReady {
+			repo.isReady = true
+			channels.ready <- true
+		}
+	} else {
+		repo.refreshTicker = time.NewTicker(options.refreshInterval)
+		repo.close = make(chan struct{})
+		repo.closed = make(chan struct{})
+		go repo.sync()
+	}
 
 	return repo
 }
@@ -126,7 +140,7 @@ func (r *repository) sync() {
 	}
 
 	// Use polling if not streaming
-	if !isStreaming {
+	if !isStreaming && !r.options.synchronousFetch {
 		r.fetchAndReportError()
 	}
 
@@ -307,9 +321,15 @@ func (r *repository) list() []api.Feature {
 }
 
 func (r *repository) Close() error {
-	close(r.close)
-	r.cancel()
-	<-r.closed
-	r.refreshTicker.Stop()
+	if !r.options.disablePolling || r.isStreaming {
+		close(r.close)
+		r.cancel()
+		<-r.closed
+	} else {
+		r.cancel()
+	}
+	if r.refreshTicker != nil {
+		r.refreshTicker.Stop()
+	}
 	return nil
 }


### PR DESCRIPTION
## About the changes

Adds two new config options available in other Unleash SDKs (Node, Java) but not yet present in the Go v5 SDK:

- **`WithDisablePolling(true)`** — stops the client from polling the Unleash server after the initial startup. The client serves whatever state was loaded from backup storage or fetched on initialisation. Intended for serverless/lambda environments, air-gapped deployments, and CI setups where toggle state only changes on redeploy.

- **`WithSynchronousFetchOnInitialisation(true)`** — makes `NewClient` block until the first fetch completes, so toggles are available immediately on return without calling `WaitForReady()`. Subsequent polling (if enabled) continues as normal in the background.

The two options compose:

| `disablePolling` | `synchronousFetch` | behaviour |
|---|---|---|
| `false` | `false` | unchanged — goroutine fetches once then polls (default) |
| `false` | `true` | `NewClient` blocks on first fetch, goroutine skips the leading fetch, polls normally |
| `true` | `false` | ready fires immediately from backup/empty state, no polling goroutine |
| `true` | `true` | `NewClient` blocks on first fetch, ready fires, no polling goroutine |

In all four cases, if the initial fetch fails the client falls back to whatever is in backup storage rather than returning an error, and `ready` still fires so the application is not blocked.

Closes #185

### Important files

- **`config.go`** — the two new `With*` option funcs and their doc comments, start here for the public API shape
- **`repository.go`** — core logic: the four-quadrant behaviour matrix, the skip-leading-fetch guard in `sync()` that prevents a double-fetch when `synchronousFetch` already succeeded, and guarded `Close()` for the no-goroutine path
- **`client_test.go`** — client-level integration tests for all four flag combinations plus the streaming interaction

## Discussion points

**`WithSynchronousFetchOnInitialisation` has no effect in streaming mode.**

In v5, the synchronous fetch path is guarded by `!repo.isStreaming`, so streaming mode is unaffected. Streaming starts the sync goroutine as normal.

**`disablePolling=true` is overridden by streaming.**

When `isStreaming=true`, the `disablePolling` flag is ignored — the sync goroutine always starts for streaming. `Close()` correctly uses the blocking shutdown path when streaming is active.

**`Close()` with `disablePolling=true` (non-streaming) does not start or wait on a goroutine.**

`r.close`, `r.closed`, and `r.refreshTicker` are only allocated when the goroutine starts. `Close()` is guarded with nil checks and skips the blocking `<-r.closed` wait, so there is no deadlock.

**Failover from sync fetch failure retries immediately.**

When `synchronousFetch=true` and the initial fetch fails, the polling goroutine's leading-fetch condition is `!r.options.synchronousFetch || !r.isReady`. This ensures the goroutine retries immediately rather than waiting a full `refreshInterval` before the client becomes ready.