### PR TITLE
fix: flush pending metrics on Close

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package unleash
 
 import (
-	stdcontext "context"
 	"fmt"
 
 	"net/http"
@@ -455,9 +454,10 @@ func (uc *Client) ImpactMetrics() *impactmetrics.MetricsAPI {
 	return uc.MetricsAPI
 }
 
-// Close stops the client from syncing data from the server. Any metrics
-// recorded since the last periodic flush are discarded. For a graceful
-// shutdown that attempts to flush buffered metrics, use Shutdown.
+// Close stops the client from syncing data from the server. It makes a
+// best-effort attempt to POST any metrics buffered since the last periodic
+// flush before returning; that final flush is bounded internally so an
+// unreachable metrics endpoint cannot hang shutdown indefinitely.
 func (uc *Client) Close() error {
 	uc.fetcher.stop()
 	uc.metrics.Close()
@@ -467,21 +467,6 @@ func (uc *Client) Close() error {
 		<-uc.closed
 	}
 	return nil
-}
-
-// Shutdown gracefully stops the client. It performs the same teardown as
-// Close but first makes a best-effort attempt to POST any metrics buffered
-// since the last periodic flush. The provided context bounds how long the
-// flush is allowed to take; if it expires, remaining metrics are dropped
-// and Shutdown returns ctx.Err().
-func (uc *Client) Shutdown(ctx stdcontext.Context) error {
-	uc.fetcher.stop()
-	err := uc.metrics.Shutdown(ctx)
-	if uc.options.listener != nil {
-		close(uc.close)
-		<-uc.closed
-	}
-	return err
 }
 
 // Errors returns the error channel for the client.

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package unleash
 
 import (
+	stdcontext "context"
 	"fmt"
 
 	"net/http"
@@ -454,7 +455,9 @@ func (uc *Client) ImpactMetrics() *impactmetrics.MetricsAPI {
 	return uc.MetricsAPI
 }
 
-// Close stops the client from syncing data from the server.
+// Close stops the client from syncing data from the server. Any metrics
+// recorded since the last periodic flush are discarded. For a graceful
+// shutdown that attempts to flush buffered metrics, use Shutdown.
 func (uc *Client) Close() error {
 	uc.fetcher.stop()
 	uc.metrics.Close()
@@ -464,6 +467,21 @@ func (uc *Client) Close() error {
 		<-uc.closed
 	}
 	return nil
+}
+
+// Shutdown gracefully stops the client. It performs the same teardown as
+// Close but first makes a best-effort attempt to POST any metrics buffered
+// since the last periodic flush. The provided context bounds how long the
+// flush is allowed to take; if it expires, remaining metrics are dropped
+// and Shutdown returns ctx.Err().
+func (uc *Client) Shutdown(ctx stdcontext.Context) error {
+	uc.fetcher.stop()
+	err := uc.metrics.Shutdown(ctx)
+	if uc.options.listener != nil {
+		close(uc.close)
+		<-uc.closed
+	}
+	return err
 }
 
 // Errors returns the error channel for the client.

--- a/metrics.go
+++ b/metrics.go
@@ -160,12 +160,28 @@ func (m *metrics) Close() error {
 	return nil
 }
 
+// Shutdown performs the same teardown as Close but first makes a
+// best-effort attempt to flush any metrics buffered since the last tick.
+// The provided ctx bounds how long the flush is allowed to take; if it
+// expires, Shutdown returns ctx.Err().
+func (m *metrics) Shutdown(ctx context.Context) error {
+	if m.options.disableMetrics {
+		return nil
+	}
+	m.ticker.Stop()
+	m.cancel()
+	close(m.close)
+	<-m.closed
+	m.flushOnShutdown(ctx)
+	return ctx.Err()
+}
+
 func (m *metrics) sync() {
 	for {
 		select {
 		case <-m.ticker.C:
 			if m.skips == 0 {
-				m.sendMetrics()
+				m.sendMetrics(m.ctx)
 			} else {
 				m.decrementSkip()
 			}
@@ -179,7 +195,7 @@ func (m *metrics) sync() {
 func (m *metrics) registerInstance() {
 	u, _ := m.options.url.Parse("./client/register")
 	payload := m.getClientData()
-	resp, err := m.doPost(u, payload)
+	resp, err := m.doPost(m.ctx, u, payload)
 
 	if err != nil {
 		m.err(err)
@@ -270,7 +286,41 @@ func (m *metrics) buildBucketAndReset(lastCloseTime time.Time) (api.Bucket, bool
 	return bucket, true
 }
 
-func (m *metrics) sendMetrics() {
+// flushOnShutdown makes a best-effort attempt to POST any buffered toggle
+// counts and impact metrics before Shutdown returns. It intentionally emits
+// no events: OnSent, OnError, and the backoff counter are all skipped
+// because the caller has committed to teardown and cannot react to them.
+// The caller-provided ctx bounds how long the POST is allowed to take.
+func (m *metrics) flushOnShutdown(ctx context.Context) {
+	bucket, ok := m.buildBucketAndReset(m.lastCloseTime)
+	collectedMetrics := impactmetrics.CollectedMetrics(m.metricRegistry.Collect())
+
+	if !ok && collectedMetrics.IsEmpty() {
+		return
+	}
+	bucket.Stop = time.Now()
+	payload := MetricsData{
+		AppName:          m.options.appName,
+		InstanceID:       m.options.instanceId,
+		ConnectionId:     m.options.connectionId,
+		Bucket:           bucket,
+		SDKVersion:       fmt.Sprintf("%s:%s", clientName, clientVersion),
+		PlatformName:     "go",
+		PlatformVersion:  runtime.Version(),
+		YggdrasilVersion: nil,
+		SpecVersion:      specVersion,
+		ImpactMetrics:    collectedMetrics,
+	}
+
+	u, _ := m.options.url.Parse("./client/metrics")
+	resp, err := m.doPost(ctx, u, payload)
+	if err != nil {
+		return
+	}
+	_ = resp.Body.Close()
+}
+
+func (m *metrics) sendMetrics(ctx context.Context) {
 	bucket, ok := m.buildBucketAndReset(m.lastCloseTime)
 	collectedMetrics := impactmetrics.CollectedMetrics(m.metricRegistry.Collect())
 
@@ -293,7 +343,7 @@ func (m *metrics) sendMetrics() {
 	}
 
 	u, _ := m.options.url.Parse("./client/metrics")
-	resp, err := m.doPost(u, payload)
+	resp, err := m.doPost(ctx, u, payload)
 	if err != nil {
 		m.err(err)
 		return
@@ -325,7 +375,7 @@ func (m *metrics) sendMetrics() {
 	}
 }
 
-func (m *metrics) doPost(url *url.URL, payload interface{}) (*http.Response, error) {
+func (m *metrics) doPost(ctx context.Context, url *url.URL, payload interface{}) (*http.Response, error) {
 	var body bytes.Buffer
 	enc := json.NewEncoder(&body)
 	if err := enc.Encode(payload); err != nil {
@@ -336,7 +386,7 @@ func (m *metrics) doPost(url *url.URL, payload interface{}) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(m.ctx)
+	req = req.WithContext(ctx)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Add("UNLEASH-APPNAME", m.options.appName)
 	req.Header.Add("UNLEASH-INSTANCEID", m.options.instanceId)

--- a/metrics.go
+++ b/metrics.go
@@ -84,6 +84,10 @@ type ClientData struct {
 	SpecVersion string `json:"specVersion"`
 }
 
+// metricsShutdownTimeout bounds the best-effort final flush performed by
+// Close so an unreachable server cannot hang shutdown indefinitely.
+const metricsShutdownTimeout = 5 * time.Second
+
 type metric struct {
 	// Name is the name of the feature toggle.
 	Name string
@@ -151,20 +155,6 @@ func newMetrics(options metricsOptions, channels metricsChannels) *metrics {
 }
 
 func (m *metrics) Close() error {
-	if !m.options.disableMetrics {
-		m.ticker.Stop()
-		m.cancel()
-		close(m.close)
-		<-m.closed
-	}
-	return nil
-}
-
-// Shutdown performs the same teardown as Close but first makes a
-// best-effort attempt to flush any metrics buffered since the last tick.
-// The provided ctx bounds how long the flush is allowed to take; if it
-// expires, Shutdown returns ctx.Err().
-func (m *metrics) Shutdown(ctx context.Context) error {
 	if m.options.disableMetrics {
 		return nil
 	}
@@ -172,8 +162,12 @@ func (m *metrics) Shutdown(ctx context.Context) error {
 	m.cancel()
 	close(m.close)
 	<-m.closed
+	// Best-effort final flush of anything buffered since the last tick.
+	// Bounded so an unreachable server cannot hang Close indefinitely.
+	ctx, cancel := context.WithTimeout(context.Background(), metricsShutdownTimeout)
+	defer cancel()
 	m.flushOnShutdown(ctx)
-	return ctx.Err()
+	return nil
 }
 
 func (m *metrics) sync() {
@@ -287,10 +281,10 @@ func (m *metrics) buildBucketAndReset(lastCloseTime time.Time) (api.Bucket, bool
 }
 
 // flushOnShutdown makes a best-effort attempt to POST any buffered toggle
-// counts and impact metrics before Shutdown returns. It intentionally emits
+// counts and impact metrics before Close returns. It intentionally emits
 // no events: OnSent, OnError, and the backoff counter are all skipped
 // because the caller has committed to teardown and cannot react to them.
-// The caller-provided ctx bounds how long the POST is allowed to take.
+// The bounded ctx keeps an unreachable server from hanging shutdown.
 func (m *metrics) flushOnShutdown(ctx context.Context) {
 	bucket, ok := m.buildBucketAndReset(m.lastCloseTime)
 	collectedMetrics := impactmetrics.CollectedMetrics(m.metricRegistry.Collect())

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -4,6 +4,7 @@
 package unleash
 
 import (
+	stdcontext "context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -133,7 +134,7 @@ func TestMetrics_DoPost(t *testing.T) {
 	m := client.metrics
 
 	serverUrl, _ := url.Parse(mockerServer)
-	res, err := m.doPost(serverUrl, &struct{}{})
+	res, err := m.doPost(m.ctx, serverUrl, &struct{}{})
 	client.Close()
 
 	assert.Nil(err, "doPost should not return an error")
@@ -656,4 +657,102 @@ func TestMetrics_NotCountingVariantsStillIncludesEmptyVariantBucket(t *testing.T
 		t.Fatalf("failed to marshal bucket: %v", err)
 	}
 	assert.Contains(t, string(raw), "\"variants\":{}")
+}
+
+// TestMetrics_ShutdownFlushesBufferedMetrics verifies that Shutdown POSTs any
+// toggle counts recorded between the last periodic tick and shutdown, rather
+// than dropping them.
+func TestMetrics_ShutdownFlushesBufferedMetrics(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).Post("/client/register").Reply(200)
+	gock.New(mockerServer).Get("/client/features").Reply(200).JSON(api.FeatureResponse{
+		Features: []api.Feature{{Name: "foo", Enabled: true}},
+	})
+
+	metricsPosted := make(chan MetricsData, 1)
+	gock.New(mockerServer).
+		Post("/client/metrics").
+		AddMatcher(func(req *http.Request, _ *gock.Request) (bool, error) {
+			body, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				return false, err
+			}
+			var md MetricsData
+			if err := json.Unmarshal(body, &md); err != nil {
+				return false, err
+			}
+			metricsPosted <- md
+			return true, nil
+		}).
+		Reply(200)
+
+	// Long interval so no periodic tick fires during the test — the only
+	// /client/metrics POST that can happen is the shutdown flush.
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithMetricsInterval(1*time.Hour),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+	client.IsEnabled("foo", FeatureOptions{})
+	client.IsEnabled("foo", FeatureOptions{})
+
+	ctx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 2*time.Second)
+	defer cancel()
+	assert.Nil(client.Shutdown(ctx), "Shutdown should not error")
+
+	select {
+	case md := <-metricsPosted:
+		toggle, ok := md.Bucket.Toggles["foo"]
+		assert.True(ok, "Shutdown flush should include the 'foo' toggle counts")
+		assert.EqualValues(2, toggle.Yes, "should have flushed 2 'yes' counts recorded before Shutdown")
+		assert.EqualValues(0, toggle.No)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a final /client/metrics POST on Shutdown, got none")
+	}
+
+	assert.True(gock.IsDone(), "all expected requests should have been made")
+}
+
+// TestMetrics_CloseDoesNotFlush documents that Close is the fast path — it
+// does not attempt to flush metrics recorded since the last periodic tick.
+// Callers who want that behavior should use Shutdown instead.
+func TestMetrics_CloseDoesNotFlush(t *testing.T) {
+	assert := assert.New(t)
+	defer gock.OffAll()
+
+	gock.New(mockerServer).Post("/client/register").Reply(200)
+	gock.New(mockerServer).Get("/client/features").Reply(200).JSON(api.FeatureResponse{
+		Features: []api.Feature{{Name: "foo", Enabled: true}},
+	})
+
+	// Deliberately register no /client/metrics mock. If Close were to flush,
+	// gock would either fail the request (surfacing an unexpected call) or
+	// the assertion below would trip.
+
+	client, err := NewClient(
+		WithUrl(mockerServer),
+		WithMetricsInterval(1*time.Hour),
+		WithAppName(mockAppName),
+		WithInstanceId(mockInstanceId),
+	)
+	assert.Nil(err, "client should not return an error")
+
+	client.WaitForReady()
+	client.IsEnabled("foo", FeatureOptions{})
+
+	assert.Nil(client.Close(), "Close should not error")
+	// Counters were reset by the register call at startup, so a non-zero
+	// count here can only come from the toggle evaluation above; Close must
+	// have left it in place rather than flushed it.
+	c, ok := client.metrics.counters.Load("foo")
+	assert.True(ok, "toggle counter should still exist after Close")
+	assert.EqualValues(1, c.(*toggleCounters).yes, "Close should not reset the counter by flushing")
+
+	assert.True(gock.IsDone(), "no /client/metrics POST expected on Close")
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -4,7 +4,6 @@
 package unleash
 
 import (
-	stdcontext "context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -659,10 +658,10 @@ func TestMetrics_NotCountingVariantsStillIncludesEmptyVariantBucket(t *testing.T
 	assert.Contains(t, string(raw), "\"variants\":{}")
 }
 
-// TestMetrics_ShutdownFlushesBufferedMetrics verifies that Shutdown POSTs any
-// toggle counts recorded between the last periodic tick and shutdown, rather
-// than dropping them.
-func TestMetrics_ShutdownFlushesBufferedMetrics(t *testing.T) {
+// TestMetrics_CloseFlushesBufferedMetrics verifies that Close POSTs any
+// toggle counts recorded between the last periodic tick and shutdown,
+// rather than dropping them.
+func TestMetrics_CloseFlushesBufferedMetrics(t *testing.T) {
 	assert := assert.New(t)
 	defer gock.OffAll()
 
@@ -702,57 +701,17 @@ func TestMetrics_ShutdownFlushesBufferedMetrics(t *testing.T) {
 	client.IsEnabled("foo", FeatureOptions{})
 	client.IsEnabled("foo", FeatureOptions{})
 
-	ctx, cancel := stdcontext.WithTimeout(stdcontext.Background(), 2*time.Second)
-	defer cancel()
-	assert.Nil(client.Shutdown(ctx), "Shutdown should not error")
+	assert.Nil(client.Close(), "Close should not error")
 
 	select {
 	case md := <-metricsPosted:
 		toggle, ok := md.Bucket.Toggles["foo"]
-		assert.True(ok, "Shutdown flush should include the 'foo' toggle counts")
-		assert.EqualValues(2, toggle.Yes, "should have flushed 2 'yes' counts recorded before Shutdown")
+		assert.True(ok, "Close flush should include the 'foo' toggle counts")
+		assert.EqualValues(2, toggle.Yes, "should have flushed 2 'yes' counts recorded before Close")
 		assert.EqualValues(0, toggle.No)
 	case <-time.After(2 * time.Second):
-		t.Fatal("expected a final /client/metrics POST on Shutdown, got none")
+		t.Fatal("expected a final /client/metrics POST on Close, got none")
 	}
 
 	assert.True(gock.IsDone(), "all expected requests should have been made")
-}
-
-// TestMetrics_CloseDoesNotFlush documents that Close is the fast path — it
-// does not attempt to flush metrics recorded since the last periodic tick.
-// Callers who want that behavior should use Shutdown instead.
-func TestMetrics_CloseDoesNotFlush(t *testing.T) {
-	assert := assert.New(t)
-	defer gock.OffAll()
-
-	gock.New(mockerServer).Post("/client/register").Reply(200)
-	gock.New(mockerServer).Get("/client/features").Reply(200).JSON(api.FeatureResponse{
-		Features: []api.Feature{{Name: "foo", Enabled: true}},
-	})
-
-	// Deliberately register no /client/metrics mock. If Close were to flush,
-	// gock would either fail the request (surfacing an unexpected call) or
-	// the assertion below would trip.
-
-	client, err := NewClient(
-		WithUrl(mockerServer),
-		WithMetricsInterval(1*time.Hour),
-		WithAppName(mockAppName),
-		WithInstanceId(mockInstanceId),
-	)
-	assert.Nil(err, "client should not return an error")
-
-	client.WaitForReady()
-	client.IsEnabled("foo", FeatureOptions{})
-
-	assert.Nil(client.Close(), "Close should not error")
-	// Counters were reset by the register call at startup, so a non-zero
-	// count here can only come from the toggle evaluation above; Close must
-	// have left it in place rather than flushed it.
-	c, ok := client.metrics.counters.Load("foo")
-	assert.True(ok, "toggle counter should still exist after Close")
-	assert.EqualValues(1, c.(*toggleCounters).yes, "Close should not reset the counter by flushing")
-
-	assert.True(gock.IsDone(), "no /client/metrics POST expected on Close")
 }


### PR DESCRIPTION
## Summary
`Client.Close()` today drops any toggle counts and impact metrics accumulated between the last periodic tick and shutdown. This PR makes `Close()` do a best-effort final flush before returning, bounded internally so an unreachable metrics endpoint can't hang shutdown.

The flush is deliberately silent (no `OnSent`/`OnError`, no backoff-counter change) because the caller has committed to teardown and cannot react to those events.

`Close()`'s signature is unchanged — this is a pure behavior fix, no API surface change.

Fixes #269.

## Notes on prior revision
An earlier version of this PR added a separate `Shutdown(ctx)` method inspired by `net/http.Server`. Per @sighphyre's review, Unleash SDKs standardize on a single lifecycle method across the ecosystem, so that was folded back into `Close()`. The bound is a hardcoded 5s; if there's later demand for tuning it, an option can be added in a follow-up.

## Test plan
- [x] `TestMetrics_CloseFlushesBufferedMetrics` — with a 1-hour tick interval so no periodic flush can have run, asserts that `Close()` still POSTs the buffered counts to `/client/metrics`
- [x] `make` (vet + tests) green
- [x] `make test-race` green