### PR TITLE
chore: bump to 6.5.0

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 const (
 	deprecatedSuffix = "/features"
 	clientName       = "unleash-go-sdk"
-	clientVersion    = "6.4.1"
+	clientVersion    = "6.5.0"
 	specVersion      = "6.1.0"
 )
 


### PR DESCRIPTION
Previous was 6.4.1 but actually there's been a bunch of things merged that warrant a 6.5.0 instead